### PR TITLE
Inital check in for CPS to Python Data Mapper

### DIFF
--- a/python-inocybe-openswitch/inocybe_openswitch/cps_parse.py
+++ b/python-inocybe-openswitch/inocybe_openswitch/cps_parse.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python
+
+'''Mapping of CPS operations onto JSON RPC'''
+
+import re
+from inocybe_tree.pathmap import no_mayhem_pop
+from inocybe_openswitch.map import GLOBAL_MAP
+import cps_utils
+import cps
+import cps_operations
+
+FIX_MODULE = re.compile(".*:.*?/")
+
+STRIP_MODULE_RE = re.compile(".*:")
+
+PREFIX_MAP = {'ietf-interfaces':'if',
+              'base-common':'base-cmn',
+              'base-interface-cmn':'base-if',
+              'base-platform-common':'platform',
+              'dell-extension':'os10-ext',
+              'dell-yang-types':'common',
+              'iana-if-type':'ianaift',
+              'ietf-inet-types':'inet',
+              'ietf-yang-types':'yang',
+              'base-if-common':'dell-base-if-cmn',
+              'dell-interface':'dell-if'}
+
+REV_PREFIX_MAP = {'if':'ietf-interfaces',
+                  'base-cmn':'base-common',
+                  'base-if':'base-interface-cmn',
+                  'platform':'base-platform-common',
+                  'os10-ext':'dell-extension',
+                  'common':'dell-yang-types',
+                  'ianaift':'iana-if-type',
+                  'inet':'ietf-inet-types',
+                  'yang':'ietf-yang-types',
+                  'dell-base-if-cmn':'base-if-common',
+                  'dell-if':'dell-interface'}
+
+def _fix_module(key):
+    '''Rewrite key from yang proper to CPS:
+       1. Remove module:
+       2. Map module onto CPS prefix
+       3. Add CPS prefix
+       Return in a CPS key form
+    '''
+    try:
+        (module, identifier) = key.split(':')
+        try:
+            return "/".join((PREFIX_MAP[module], identifier))
+        except KeyError:
+            return "/".join((module, identifier))
+    except ValueError:
+        return key
+
+def _reverse_mod_map(key):
+    '''Map prefix to module - back from CPS'''
+    try:
+        return REV_PREFIX_MAP[key]
+    except KeyError:
+        return key
+
+def _fix_n_keep_module(key, pos):
+    '''Rewrite data piece from yang proper to CPS:
+       map onto a key, value tupple as used in the
+       yin_path family of functions
+    '''
+    try:
+        return (PREFIX_MAP[key[:pos]], key[pos+1:])
+    except KeyError:
+        return (key[:pos], key[pos+1:])
+
+def _fix_module_full(orig_path, key):
+    '''Rewrite key from yang proper to CPS and grow CPS key:
+    '''
+    pos = key.find(":")
+    if pos == -1:
+        if orig_path is not None:
+            return "/".join((orig_path, key))
+        else:
+            return key
+
+    (prefix, postfix) = _fix_n_keep_module(key, pos)
+    if orig_path is not None:
+        return "/".join((prefix, orig_path, postfix))
+    else:
+        return "/".join((prefix, postfix))
+
+def _form_subkey(key, subkey):
+    '''key formation helper - very common piece
+       of code throughout - join two subkeys one of
+       which may be None
+    '''
+    if subkey is not None and subkey != "":
+        if key is not None:
+            return "/".join((key, subkey))
+        return subkey
+    else:
+        if key is not None and key != "":
+            return key
+        return ""
+
+def _prepend_prefix(yin_key, data):
+    '''Prepend the current level to the keys in tree so it
+       conforms to yin conventions.
+    '''
+    result = {}
+    if data is not None:
+        for (key, value) in data.items():
+            result[_form_subkey(yin_key, key)] = value
+    return result
+
+def _yin_list_path(supplied_path):
+    '''List subcase for the path walker'''
+    item_spec = supplied_path[0]
+    result = {}
+    subkey = None
+    for (key, value) in item_spec.items():
+        key = _fix_module(key)
+        if isinstance(value, dict):
+            (subkey, data) = _yin_other_path(value)
+            if data is not None:
+                result.update(_prepend_prefix(key, data))
+            subkey = _form_subkey(key, subkey)
+        elif isinstance(value, list):
+            (subkey, d_data) = _yin_list_path(value)
+            result.update(_prepend_prefix(key, d_data))
+            subkey = _form_subkey(key, subkey)
+        else:
+            result.update({key: value})
+    return (subkey, result)
+
+def _yin_other_path(supplied_path):
+    '''Container and scalar subcase for the path walker'''
+    try:
+        (key, value) = no_mayhem_pop(supplied_path)
+        key = _fix_module(key)
+        (yin_form, data) = _yin_path(value)
+        return (_form_subkey(key, yin_form), _prepend_prefix(key, data))
+    except ValueError:
+        return (None, None)
+    except TypeError:
+        return (None, None)
+
+def _yin_path(supplied_path):
+    '''Actual path walker for effective path'''
+    if isinstance(supplied_path, list):
+        return _yin_list_path(supplied_path)
+    # container case
+    return _yin_other_path(supplied_path)
+
+def _prep_data(orig_path, data):
+    '''Set correct encoding, remap or otherwise massage all data elements'''
+    if isinstance(data, str):
+        return data
+    if isinstance(data, unicode):
+        return data.encode('ascii')
+    result = {}
+    for (key, value) in data.items():
+        if isinstance(key, unicode):
+            key = key.encode('ascii')
+        key = _fix_module_full(orig_path, key).encode('ascii')
+        if isinstance(value, unicode):
+            value = value.encode('ascii')
+
+        if isinstance(value, str):
+            pos = value.find(":")
+            if pos != -1:
+                try:
+                    value = ":".join((PREFIX_MAP[value[:pos]], value[pos + 1:]))
+                except KeyError:
+                    pass
+
+        value = GLOBAL_MAP.to_cps(key, value)
+
+        if isinstance(value, dict):
+            result[key] = _prep_data(key, value)
+        elif isinstance(value, list):
+            nextl = []
+            for element in value:
+                nextl.append(_prep_data(key, element))
+            result[key] = nextl
+        else:
+            result[key] = value
+    return result
+
+CPS_RE = re.compile("^.*?/")
+
+def _is_in_cps(key):
+    '''Check if key is in CPS'''
+    try:
+        return cps.type(key) is not None
+    except Exception:
+        return False
+
+def _scrub_data(data):
+    '''Make sure each key is recognized by CPS
+       Our adjustment algorithm tends to add in some cases
+       additional module qualifiers (or they are inconsistent),
+       dunno...
+    '''
+    res = {}
+    for (key, value) in data.items():
+        while key.find("/") != -1:
+            if _is_in_cps(key):
+                res[key] = value
+                break
+            key = CPS_RE.sub("", key)
+
+    return res
+
+def yin_path(supplied_path):
+    '''YIN has no means to present a path to a list element.
+       As a result, instead of presenting key in the path component,
+       OpenSwitch uses partially formed data as a selection argument.
+       We will walk down the supplied path and isolate the key as a
+       "data snippet"
+    '''
+    (yin_form, data) = _yin_path(supplied_path)
+    return (yin_form, _scrub_data(_prep_data(None, data)))
+
+def _do_convert_result(in_path, element_path, value):
+    '''Recursive worker for result conversion - returns a key-data pair'''
+    regexp = re.compile("(.*)(" + in_path + "/)(.*)")
+    cps_type = cps.type(element_path)
+    rma = regexp.match(element_path)
+    mod_pref = rma.group(1)
+    key = rma.group(3)
+    if len(mod_pref) > 0:
+        key = ":".join((_reverse_mod_map(mod_pref[:-1]), key))
+    if cps_type["attribute_type"] == "leaf-list":
+        ylist = []
+        for element in value:
+            ylist.append(cps_utils.cps_attr_types_map.from_data(element_path, element))
+        result = {key:ylist}
+    elif cps_type["attribute_type"] == "list":
+        ylist = []
+        for element in value.values():
+            list_elem = {}
+            for (subkey, subvalue) in element.items():
+                list_elem.update(_do_convert_result(element_path, subkey, subvalue))
+            ylist.append(list_elem)
+        result = {key:ylist}
+    elif cps_type["attribute_type"] == "container":
+        container = {}
+        for (subkey, subvalue) in value.items():
+            container.update(_do_convert_result(element_path, subkey, subvalue))
+        result = {key:container}
+    else:
+        final = cps_utils.cps_attr_types_map.from_data(element_path, value)
+        result = {key:GLOBAL_MAP.from_cps(element_path, final)}
+    return result
+
+def prep_path(in_path, element):
+    '''Strip one or more elements from the right side of a path
+       until is found in one of the keys in the element
+    '''
+    
+
+    score = 0
+    old_score = 0
+    prev_path = in_path
+
+    while in_path.find("/") != -1:
+        score = 0
+        found = True
+        for key in element['data'].keys():
+            if key != "cps/key_data" and key != "cps/object-group/return-code" and key.find(in_path) == -1:
+                found = False
+            else:
+                score = score + 1
+        if found:
+            return in_path
+
+        if score <= old_score:
+            # we are returning a path by score. This means there is no perfect match and the result is polluted
+
+            for key in element['data'].keys():
+                if key.find(in_path) == -1:
+                    del element['data'][key]
+
+            return prev_path
+        
+        prev_path = in_path
+        old_score = score
+        in_path = in_path[in_path.find("/") + 1:]
+
+    
+
+
+def convert_result(in_path, element):
+    '''Convert an openswitch cps result to a form which can be serialized
+       into JSON
+    '''
+    result = {}
+
+    for (key, value) in element['data'].items():
+        if key != 'cps/key_data':
+            result.update(_do_convert_result(in_path, key, value))
+        else:
+            for (kkey, vvalue) in value.items():
+                result.update(_do_convert_result(in_path, kkey, vvalue))
+    return result
+
+class Transaction(object):
+    '''A mapper of JSON RPC to CPS Transactions'''
+
+    def __init__(self):
+        self._cps_tx = []
+        self._bus_tx = None
+
+
+    def create(self, txid):
+        '''Create a transaction'''
+        self._bus_tx = txid
+
+    def read(self, path):
+        '''Read - to be mapped on a JSON RPC read for a this entity
+           argument is a json rpc path.
+        '''
+        (yin_form, data) = yin_path(path)
+
+        needs_adjust = True
+        cps_obj = None
+        try:
+            cps_obj = cps_utils.CPSObject(yin_form, data=data)
+        except ValueError:
+            return None
+        k = [cps_obj.get()]
+        res_list = []
+        cps.get(k, res_list)
+        result = []
+        for element in res_list:
+            if needs_adjust:
+                yin_form = prep_path(yin_form, element)
+                needs_adjust = False
+            result.append(convert_result(yin_form, element))
+        cps_type = cps.type(yin_form)
+        try:
+            if cps_type["attribute_type"] == "list":
+                if data != {}:
+                    if len(result) == 0:
+                        return None
+                    else:
+                        return result[0]
+                else:
+                    return result
+            return result[0]
+        except IndexError:
+            return None
+
+    def exists(self, path):
+        '''For now just read and check if it is None'''
+        return self.read(path) is not None
+
+    def _prep_cps_op(self,  orig_path, path, data):
+        '''Shared code for transactional CPS ops'''
+        (oyin_form, opath_data) = yin_path(orig_path)
+        data = _prep_data(oyin_form, data)
+
+        (yin_form, path_data) = yin_path(path)
+        data.update(path_data)
+
+        return cps_utils.CPSObject(yin_form, data=data)
+
+    def put(self, orig_path, path, data):
+        '''Put - create a new data element.'''
+        self._cps_tx.append({'change':self._prep_cps_op(orig_path, path, data).get(), 'operation': 'create'})
+
+    def rpc(self, orig_path, path, data):
+        '''Execute an RPC.'''
+        self._cps_tx.append({'change':self._prep_cps_op(orig_path, path, data).get(), 'operation': 'action'})
+
+    def merge(self, orig_path, path, data):
+        '''Set - set value in an existing element.
+        '''
+        if len(data) == 0:
+            return
+        self._cps_tx.append({'change':self._prep_cps_op(orig_path, path, data).get(), 'operation': 'set'})
+
+    def delete(self, path):
+        '''delete - delete a data element.
+        '''
+        (yin_form, path_data) = yin_path(path)
+        cps_obj = cps_utils.CPSObject(yin_form, data=path_data)
+        self._cps_tx.append({'change':cps_obj.get(), 'operation': 'delete'})
+
+
+    def commit(self):
+        '''Commit - commit the existing transaction list'''
+        if len(self._cps_tx) == 0:
+            return True
+        result = cps.transaction(self._cps_tx)
+        if result:
+            return True
+        # The mapping between set/create in restconf, json rpc, etc
+        # and CPS is not  perfect, sometimes CPS needs to be given a
+        # set where upstream tries a create. 
+        for oper in self._cps_tx:
+            if oper['operation'] == 'create':
+                oper['operation'] = 'set'
+        return cps.transaction(self._cps_tx)

--- a/python-inocybe-openswitch/inocybe_openswitch/flatlandia.py
+++ b/python-inocybe-openswitch/inocybe_openswitch/flatlandia.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+'''Steamroller routines. Process data and make it flat.
+This module contains functions needed to flatten dicts and
+other data structures so that they can be passed to the CPS
+API.
+'''
+
+import re
+from inocybe_tree.pathmap import PathMap
+from inocybe_tree.pathmap import no_mayhem_pop
+
+PATH_SPLITTER = re.compile("\/")
+PREF_SPLITTER = re.compile(":")
+
+def build_list_item(item):
+    '''Flatten a dict so it can be used as a cps argument
+       returns an array where each row has two items -
+       1. Representation of the path to an item (as a list)
+       2. The actual item value
+       It will barf if given a list anywhere, that's intended
+       as CPS API does not allow for list nesting
+    '''
+    result = [] # list of two element arrays - first is an
+                # array representation of the path
+    for (key, value) in item.items():
+        flat = []
+        if isinstance(value, dict):
+            for (flattened, value) in build_list_item(value):
+                flat = [[key], value]
+                flat[0].extend(flattened)
+        else:
+            flat = [[key], value]
+        result.append(flat)
+    return result
+
+def _build_path(path):
+    '''Build an ugly reduced semantics path'''
+    if len(path) == 0:
+        return {}
+    key = path.pop(0)
+    return {key:_build_path(path)}
+
+def build_result(cps_result, template_pathmap):
+    '''Rewrite CPS result as pathmap data
+       cps returns a result as a list of key-value pairs
+       where the key is a [augentation/]module/path.
+    '''
+    for item in cps_result:
+        path = PATH_SPLITTER.split(item[0])
+        while len(path) > 0:
+            z = _build_path(list(path))
+            result = template_pathmap.mapnode(z)
+            if result is not None:
+                result.data = item[1]
+                break
+            path.pop(0)
+
+    return template_pathmap.to_data()

--- a/python-inocybe-openswitch/inocybe_openswitch/map.py
+++ b/python-inocybe-openswitch/inocybe_openswitch/map.py
@@ -1,0 +1,1001 @@
+#!/usr/bin/env python
+
+'''Temporary mapping of CPS operations onto JSON RPC
+This should be replaced completely using an interface into the CPS
+Schema.
+'''
+
+import re
+
+class TypeMap(object):
+    '''Perform type mappings for cases where CPS does not do
+       it correctly
+    '''
+    def __init__(self, init_map):
+        self.the_map = init_map
+
+    def add(self, key, parsers):
+        '''Add a parser to map. Parsers are a tupple of in/out'''
+        self.the_map[key] = parsers
+
+    def delete(self, key):
+        '''Remove a parser to a map'''
+        del self.the_map[key]
+
+    def to_cps(self, key, data):
+        '''Convert to cps'''
+        try:
+            (to_cps, from_cps) = self.the_map[key]
+            return to_cps(data)
+        except KeyError:
+            return data
+
+    def from_cps(self, key, data):
+        '''Convert to cps'''
+        try:
+            (to_cps, from_cps) = self.the_map[key]
+            return from_cps(data)
+        except KeyError:
+            return data
+
+def _bool_to_cps(data):
+    '''Convert boolean to archaic C (modern C has bool)'''
+    if data:
+        return 1
+    else:
+        return 0
+
+def _bool_from_cps(data):
+    '''Convert boolean to archaic C (modern C has bool)'''
+    return data != 0
+
+def _strip_module_to_cps(data):
+    '''Convert boolean to archaic C (modern C has bool)'''
+    return data
+
+MODULE_RE = re.compile(".*:")
+
+def _strip_module_from_cps(data):
+    '''Convert boolean to archaic C (modern C has bool)'''
+    return MODULE_RE.sub("", data)
+
+FIX_IF_TYPE_RE = re.compile("iana-if-type:")
+REV_FIX_IF_TYPE_RE = re.compile("ianaift:")
+
+def _fix_iftype_to_cps(data):
+    '''Convert boolean to archaic C (modern C has bool)'''
+    return FIX_IF_TYPE_RE.sub("ianaift:", data)
+
+def _fix_iftype_from_cps(data):
+    '''Convert boolean to archaic C (modern C has bool)'''
+    return REV_FIX_IF_TYPE_RE.sub("iana-if-type:", data)
+
+
+########################################################
+#
+# EVERYTHING FROM HERE DOWNWARDS SHOULD BECOME GENERATED
+#
+########################################################
+
+VLAN_MAP = {"MANAGEMENT":2, "DATA":1}
+REV_VLAN_MAP = {2:"MANAGEMENT", 1:"DATA"}
+
+def _fix_vlan_type_to_cps(data):
+    '''Fix vlan type to CPS'''
+    return VLAN_MAP[data]
+
+def _fix_vlan_type_from_cps(data):
+    '''Convert vlan type to enum'''
+    return REV_VLAN_MAP[data]
+
+DUPLEX_MAP = {"full":1, "half":2, "auto":3}
+REV_DUPLEX_MAP = {1:"full", 2:"half", 3:"auto"}
+
+def _fix_duplex_type_to_cps(data):
+    '''Fix vlan type to CPS'''
+    return DUPLEX_MAP[data]
+
+def _fix_duplex_type_from_cps(data):
+    '''Convert vlan type to enum'''
+    return REV_DUPLEX_MAP[data]
+
+MODE_MAP = {"MODE_NONE":1, "MODE_L2":2, "MODE_L2HYBRID":3, "MODE_L3":4, "MODE_L2DISABLED":5}
+REV_MODE_MAP = {1:"MODE_NONE", 2:"MODE_L2", 3:"MODE_L2HYBRID", 4:"MODE_L3", 5:"MODE_L2DISABLED"}
+
+def _fix_mode_to_cps(data):
+    '''Fix vlan type to CPS'''
+    return MODE_MAP[data]
+
+def _fix_mode_from_cps(data):
+    '''Convert vlan type to enum'''
+    return REV_MODE_MAP[data]
+
+
+SPEED_MAP = {"0MBPS":0, "10MBPS":1, "100MBPS":2, "1GIGE":3, "10GIGE":4,
+             "25GIGE":5, "40GIGE":6, "100GIGE":7, "AUTO":8, "20GIGE":9,
+             "50GIGE":10, "200GIGE":11, "400GIGE":12, "4GFC":13, "8GFC":14,
+             "16GFC":15, "32GFC":16}
+REV_SPEED_MAP = {0:"0MBPS", 1:"10MBPS", 2:"100MBPS", 3:"1GIGE", 4:"10GIGE",
+                 5:"25GIGE", 6:"40GIGE", 7:"100GIGE", 8:"AUTO", 9:"20GIGE",
+                 10:"50GIGE", 11:"200GIGE", 12:"400GIGE", 13:"4GFC", 14:"8GFC",
+                 15:"16GFC", 16:"32GFC"}
+
+def _fix_speed_to_cps(data):
+    '''Fix ifspeed to CPS'''
+    return SPEED_MAP[data]
+
+def _fix_speed_from_cps(data):
+    '''Convert ifspeed to enum'''
+    return REV_SPEED_MAP[data]
+
+REV_MEDIA_MAP = {1:"AR_POPTICS_NOTPRESENT",
+2:"AR_POPTICS_UNKNOWN",
+3:"AR_POPTICS_NOTSUPPORTED",
+4:"AR_SFPPLUS_10GBASE_USR",
+5:"AR_SFPPLUS_10GBASE_SR",
+6:"AR_SFPPLUS_10GBASE_LR",
+7:"AR_SFPPLUS_10GBASE_ER",
+8:"AR_SFPPLUS_10GBASE_ZR",
+9:"AR_SFPPLUS_10GBASE_CX4",
+10:"AR_SFPPLUS_10GBASE_LRM",
+11:"AR_SFPPLUS_10GBASE_T",
+12:"AR_SFPPLUS_10GBASE_CUHALFM",
+13:"AR_SFPPLUS_10GBASE_CU1M",
+14:"AR_SFPPLUS_10GBASE_CU2M",
+15:"AR_SFPPLUS_10GBASE_CU3M",
+16:"AR_SFPPLUS_10GBASE_CU5M",
+17:"AR_SFPPLUS_10GBASE_CU7M",
+18:"AR_SFPPLUS_10GBASE_CU10M",
+19:"AR_SFPPLUS_10GBASE_ACU7M",
+20:"AR_SFPPLUS_10GBASE_ACU10M",
+21:"AR_SFPPLUS_10GBASE_ACU15M",
+22:"AR_SFPPLUS_10GBASE_DWDM",
+23:"AR_SFPPLUS_10GBASE_DWDM_40KM",
+24:"AR_SFPPLUS_10GBASE_DWDM_80KM",
+25:"AR_QSFP_40GBASE_SR4",
+26:"AR_QSFP_40GBASE_SR4_EXT",
+27:"AR_QSFP_40GBASE_LR4",
+28:"AR_QSFP_40GBASE_LM4",
+29:"AR_QSFP_40GBASE_PSM4_LR",
+30:"AR_QSFP_40GBASE_PSM4_1490NM",
+31:"AR_QSFP_40GBASE_PSM4_1490NM_1M",
+32:"AR_QSFP_40GBASE_PSM4_1490NM_3M",
+33:"AR_QSFP_40GBASE_PSM4_1490NM_5M",
+34:"AR_4x1_1000BASE_T",
+35:"AR_QSFP_40GBASE_CR4_HAL_M",
+36:"AR_QSFP_40GBASE_CR4_1M",
+37:"AR_QSFP_40GBASE_CR4_2M",
+38:"AR_QSFP_40GBASE_CR4_3M",
+39:"AR_QSFP_40GBASE_CR4_5M",
+40:"AR_QSFP_40GBASE_CR4_7M",
+41:"AR_QSFP_40GBASE_CR4_10M",
+42:"AR_QSFP_40GBASE_CR4_50M",
+43:"AR_QSFP_40GBASE_CR4",
+44:"AR_4x10_10GBASE_CR1_HAL_M",
+45:"AR_4x10_10GBASE_CR1_1M",
+46:"AR_4x10_10GBASE_CR1_3M",
+47:"AR_4x10_10GBASE_CR1_5M",
+48:"AR_4x10_10GBASE_CR1_7M",
+49:"AR_SFPPLUS_FC_8GBASE_SR",
+50:"AR_SFPPLUS_FC_8GBASE_IR",
+51:"AR_SFPPLUS_FC_8GBASE_MR",
+52:"AR_SFPPLUS_FC_8GBASE_LR",
+53:"SFP_SX",
+54:"SFP_LX",
+55:"SFP_ZX",
+56:"SFP_CX",
+57:"SFP_DX",
+58:"SFP_T",
+59:"SFP_FX",
+60:"SFP_CWDM",
+61:"SFP_IR1",
+62:"SFP_LR1",
+63:"SFP_LR2",
+64:"SFP_BX10",
+65:"SFP_PX",
+66:"4x_10GBASE_SR_AOCXXM",
+67:"QSFP_40GBASE_SM4",
+68:"QSFP_40GBASE_ER4",
+69:"QSFP_4x10_10GBASE_CR1_2M",
+70:"SFPPLUS_10GBASE_ZR_TUNABLE",
+71:"AR_QSFP28_100GBASE_SR4",
+72:"AR_QSFP28_100GBASE_LR4",
+73:"AR_QSFP28_100GBASE_CWDM4",
+74:"AR_QSFP28_100GBASE_PSM4_IR",
+75:"AR_QSFP28_100GBASE_CR4",
+76:"AR_QSFP28_100GBASE_AOC",
+77:"AR_QSFP28_100GBASE_CR4_HAL_M",
+78:"AR_QSFP28_100GBASE_CR4_1M",
+79:"AR_QSFP28_100GBASE_CR4_2M",
+80:"AR_QSFP28_100GBASE_CR4_3M",
+81:"AR_QSFP28_100GBASE_CR4_4M",
+82:"AR_QSFP28_100GBASE_CR4_5M",
+83:"QSFP28_100GBASE_CR4_7M",
+84:"QSFP28_100GBASE_CR4_10M",
+85:"QSFP28_100GBASE_CR4_50M",
+86:"4X25_25GBASE_CR1_HALF_M",
+87:"4X25_25GBASE_CR1_1M",
+88:"4X25_25GBASE_CR1_2M",
+89:"4X25_25GBASE_CR1_3M",
+90:"4X25_25GBASE_CR1_4M",
+91:"4X25_25GBASE_CR1",
+92:"2X50_50GBASE_CR2_HALF_M",
+93:"2X50_50GBASE_CR2_1M",
+94:"2X50_50GBASE_CR2_2M",
+95:"2X50_50GBASE_CR2_3M",
+96:"2X50_50GBASE_CR2_4M",
+97:"2X50_50GBASE_CR2",
+98:"SFP28_25GBASE_CR1",
+99:"SFP28_25GBASE_CR1_HALF_M",
+100:"SFP28_25GBASE_CR1_1M",
+101:"SFP28_25GBASE_CR1_2M",
+102:"SFP28_25GBASE_CR1_3M",
+103:"QSFPPLUS_50GBASE_CR2",
+104:"QSFPPLUS_50GBASE_CR2_1M",
+105:"QSFPPLUS_50GBASE_CR2_2M",
+106:"QSFPPLUS_50GBASE_CR2_3M",
+107:"QSFP_40GBASE_BIDI",
+108:"QSFP_40GBASE_AOC",
+109:"QSFP28_100GBASE_LR4_LITE",
+110:"QSFP28_100GBASE_ER4",
+111:"QSFP28_100GBASE_ACC",
+112:"SFP28_25GBASE_SR",
+113:"SFPPLUS_10GBASE_SR_AOCXXM",
+114:"SFP_BX10_UP",
+115:"SFP_BX10_DOWN",
+116:"SFP_BX40_UP",
+117:"SFP_BX40_DOWN",
+118:"SFP_BX80_UP",
+119:"SFP_BX80_DOWN",
+120:"QSFP28_100GBASE_PSM4_PIGTAIL",
+121:"QSFP28_100GBASE_SWDM4",
+122:"QSFP_40GBASE_PSM4_PIGTAIL",
+123:"AR_QSFP_40GBASE_CR4_HALFM",
+124:"AR_4x10_10GBASE_CR1_HALFM",
+125:"AR_QSFP28_100GBASE_CR4_HALFM",
+126:"4X25_25GBASE_CR1_HALFM",
+127:"2X50_50GBASE_CR2_HALFM",
+128:"SFP28_25GBASE_CR1_HALFM",
+129:"SFPPLUS_8GBASE_FC_SW",
+130:"SFPPLUS_8GBASE_FC_LW",
+131:"SFPPLUS_16GBASE_FC_SW",
+132:"SFPPLUS_16GBASE_FC_LW",
+133:"QSFPPLUS_64GBASE_FC_SW4",
+134:"QSFPPLUS_4X16_16GBASE_FC_SW",
+135:"QSFPPLUS_64GBASE_FC_LW4",
+136:"QSFPPLUS_4X16_16GBASE_FC_LW",
+137:"QSFP28_128GBASE_FC_SW4",
+138:"QSFP28_4X32_32GBASE_FC_SW",
+139:"QSFP28_128GBASE_FC_LW4",
+140:"QSFP28_4X32_32GBASE_FC_LW",
+141:"SFP28_32GBASE_FC_SW",
+142:"SFP28_32GBASE_FC_LW",
+143:"SFP28_25GBASE_SR_NOF",
+144:"SFP28_25GBASE_eSR",
+145:"SFP28_25GBASE_LR",
+146:"SFP28_25GBASE_LR_LITE",
+147:"SFP28_25GBASE_SR_AOCXXM",
+148:"SFP28_25GBASE_CR1_LPBK",
+149:"QSFP28-DD_200GBASE_CR4_HALFM",
+150:"QSFP28-DD_200GBASE_CR4_1M",
+151:"QSFP28-DD_200GBASE_CR4_2M",
+152:"QSFP28-DD_200GBASE_CR4_3M",
+153:"QSFP28-DD_200GBASE_CR4_5M",
+154:"QSFP28-DD_200GBASE_CR4",
+155:"QSFP28-DD_200GBASE_CR4_1_HALFM",
+156:"QSFP28-DD_200GBASE_CR4_2_HALFM",
+157:"QSFP28-DD_2x100GBASE_CR4_1M",
+158:"QSFP28-DD_2x100GBASE_CR4_2M",
+159:"QSFP28-DD_2x100GBASE_CR4_3M",
+160:"QSFP28-DD_8x25GBASE_CR4_1M",
+161:"QSFP28-DD_8x25GBASE_CR4_2M",
+162:"QSFP28-DD_8x25GBASE_CR4_3M",
+163:"QSFP28-DD_200GBASE_CR4_LPBK",
+164:"SFPPLUS_10GBASE_CR_1_HALFM",
+165:"SFPPLUS_10GBASE_CR_2_HALFM",
+166:"SFPPLUS_10GBASE_CR_1M",
+167:"SFPPLUS_10GBASE_CR_2M",
+168:"SFPPLUS_10GBASE_CR_3M",
+169:"SFPPLUS_10GBASE_CR_4M",
+170:"SFPPLUS_10GBASE_CR_5M",
+171:"QSFP28-DD_200GBASE_SR4_HALFM",
+172:"QSFP28-DD_200GBASE_SR4_1M",
+173:"QSFP28-DD_200GBASE_SR4_2M",
+174:"QSFP28-DD_200GBASE_SR4_3M",
+175:"QSFP28-DD_200GBASE_SR4_5M",
+176:"QSFP28-DD_200GBASE_SR4",
+177:"QSFP28-DD_200GBASE_SR4_1_HALFM",
+178:"QSFP28-DD_200GBASE_SR4_2_HALFM",
+179:"1GBASE_COPPER",
+180:"10GBASE_COPPER",
+181:"25GBASE_BACKPLANE",
+182:"SFPPLUS_10GBASE_SR_AOC1M",
+183:"SFPPLUS_10GBASE_SR_AOC3M",
+184:"SFPPLUS_10GBASE_SR_AOC5M",
+185:"SFPPLUS_10GBASE_SR_AOC10M",
+186:"QSFPPLUS_4X10_10GBASE_SR_AOC10M",
+187:"QSFPPLUS_40GBASE_SR_AOC3M",
+188:"QSFPPLUS_40GBASE_SR_AOC5M",
+189:"QSFPPLUS_40GBASE_SR_AOC7M",
+190:"QSFPPLUS_40GBASE_SR_AOC10M",
+}
+OUT_MEDIA_MAP = {"AR_POPTICS_NOTPRESENT":1,
+"AR_POPTICS_UNKNOWN":2,
+"AR_POPTICS_NOTSUPPORTED":3,
+"AR_SFPPLUS_10GBASE_USR":4,
+"AR_SFPPLUS_10GBASE_SR":5,
+"AR_SFPPLUS_10GBASE_LR":6,
+"AR_SFPPLUS_10GBASE_ER":7,
+"AR_SFPPLUS_10GBASE_ZR":8,
+"AR_SFPPLUS_10GBASE_CX4":9,
+"AR_SFPPLUS_10GBASE_LRM":10,
+"AR_SFPPLUS_10GBASE_T":11,
+"AR_SFPPLUS_10GBASE_CUHALFM":12,
+"AR_SFPPLUS_10GBASE_CU1M":13,
+"AR_SFPPLUS_10GBASE_CU2M":14,
+"AR_SFPPLUS_10GBASE_CU3M":15,
+"AR_SFPPLUS_10GBASE_CU5M":16,
+"AR_SFPPLUS_10GBASE_CU7M":17,
+"AR_SFPPLUS_10GBASE_CU10M":18,
+"AR_SFPPLUS_10GBASE_ACU7M":19,
+"AR_SFPPLUS_10GBASE_ACU10M":20,
+"AR_SFPPLUS_10GBASE_ACU15M":21,
+"AR_SFPPLUS_10GBASE_DWDM":22,
+"AR_SFPPLUS_10GBASE_DWDM_40KM":23,
+"AR_SFPPLUS_10GBASE_DWDM_80KM":24,
+"AR_QSFP_40GBASE_SR4":25,
+"AR_QSFP_40GBASE_SR4_EXT":26,
+"AR_QSFP_40GBASE_LR4":27,
+"AR_QSFP_40GBASE_LM4":28,
+"AR_QSFP_40GBASE_PSM4_LR":29,
+"AR_QSFP_40GBASE_PSM4_1490NM":30,
+"AR_QSFP_40GBASE_PSM4_1490NM_1M":31,
+"AR_QSFP_40GBASE_PSM4_1490NM_3M":32,
+"AR_QSFP_40GBASE_PSM4_1490NM_5M":33,
+"AR_4x1_1000BASE_T":34,
+"AR_QSFP_40GBASE_CR4_HAL_M":35,
+"AR_QSFP_40GBASE_CR4_1M":36,
+"AR_QSFP_40GBASE_CR4_2M":37,
+"AR_QSFP_40GBASE_CR4_3M":38,
+"AR_QSFP_40GBASE_CR4_5M":39,
+"AR_QSFP_40GBASE_CR4_7M":40,
+"AR_QSFP_40GBASE_CR4_10M":41,
+"AR_QSFP_40GBASE_CR4_50M":42,
+"AR_QSFP_40GBASE_CR4":43,
+"AR_4x10_10GBASE_CR1_HAL_M":44,
+"AR_4x10_10GBASE_CR1_1M":45,
+"AR_4x10_10GBASE_CR1_3M":46,
+"AR_4x10_10GBASE_CR1_5M":47,
+"AR_4x10_10GBASE_CR1_7M":48,
+"AR_SFPPLUS_FC_8GBASE_SR":49,
+"AR_SFPPLUS_FC_8GBASE_IR":50,
+"AR_SFPPLUS_FC_8GBASE_MR":51,
+"AR_SFPPLUS_FC_8GBASE_LR":52,
+"SFP_SX":53,
+"SFP_LX":54,
+"SFP_ZX":55,
+"SFP_CX":56,
+"SFP_DX":57,
+"SFP_T":58,
+"SFP_FX":59,
+"SFP_CWDM":60,
+"SFP_IR1":61,
+"SFP_LR1":62,
+"SFP_LR2":63,
+"SFP_BX10":64,
+"SFP_PX":65,
+"4x_10GBASE_SR_AOCXXM":66,
+"QSFP_40GBASE_SM4":67,
+"QSFP_40GBASE_ER4":68,
+"QSFP_4x10_10GBASE_CR1_2M":69,
+"SFPPLUS_10GBASE_ZR_TUNABLE":70,
+"AR_QSFP28_100GBASE_SR4":71,
+"AR_QSFP28_100GBASE_LR4":72,
+"AR_QSFP28_100GBASE_CWDM4":73,
+"AR_QSFP28_100GBASE_PSM4_IR":74,
+"AR_QSFP28_100GBASE_CR4":75,
+"AR_QSFP28_100GBASE_AOC":76,
+"AR_QSFP28_100GBASE_CR4_HAL_M":77,
+"AR_QSFP28_100GBASE_CR4_1M":78,
+"AR_QSFP28_100GBASE_CR4_2M":79,
+"AR_QSFP28_100GBASE_CR4_3M":80,
+"AR_QSFP28_100GBASE_CR4_4M":81,
+"AR_QSFP28_100GBASE_CR4_5M":82,
+"QSFP28_100GBASE_CR4_7M":83,
+"QSFP28_100GBASE_CR4_10M":84,
+"QSFP28_100GBASE_CR4_50M":85,
+"4X25_25GBASE_CR1_HALF_M":86,
+"4X25_25GBASE_CR1_1M":87,
+"4X25_25GBASE_CR1_2M":88,
+"4X25_25GBASE_CR1_3M":89,
+"4X25_25GBASE_CR1_4M":90,
+"4X25_25GBASE_CR1":91,
+"2X50_50GBASE_CR2_HALF_M":92,
+"2X50_50GBASE_CR2_1M":93,
+"2X50_50GBASE_CR2_2M":94,
+"2X50_50GBASE_CR2_3M":95,
+"2X50_50GBASE_CR2_4M":96,
+"2X50_50GBASE_CR2":97,
+"SFP28_25GBASE_CR1":98,
+"SFP28_25GBASE_CR1_HALF_M":99,
+"SFP28_25GBASE_CR1_1M":100,
+"SFP28_25GBASE_CR1_2M":101,
+"SFP28_25GBASE_CR1_3M":102,
+"QSFPPLUS_50GBASE_CR2":103,
+"QSFPPLUS_50GBASE_CR2_1M":104,
+"QSFPPLUS_50GBASE_CR2_2M":105,
+"QSFPPLUS_50GBASE_CR2_3M":106,
+"QSFP_40GBASE_BIDI":107,
+"QSFP_40GBASE_AOC":108,
+"QSFP28_100GBASE_LR4_LITE":109,
+"QSFP28_100GBASE_ER4":110,
+"QSFP28_100GBASE_ACC":111,
+"SFP28_25GBASE_SR":112,
+"SFPPLUS_10GBASE_SR_AOCXXM":113,
+"SFP_BX10_UP":114,
+"SFP_BX10_DOWN":115,
+"SFP_BX40_UP":116,
+"SFP_BX40_DOWN":117,
+"SFP_BX80_UP":118,
+"SFP_BX80_DOWN":119,
+"QSFP28_100GBASE_PSM4_PIGTAIL":120,
+"QSFP28_100GBASE_SWDM4":121,
+"QSFP_40GBASE_PSM4_PIGTAIL":122,
+"AR_QSFP_40GBASE_CR4_HALFM":123,
+"AR_4x10_10GBASE_CR1_HALFM":124,
+"AR_QSFP28_100GBASE_CR4_HALFM":125,
+"4X25_25GBASE_CR1_HALFM":126,
+"2X50_50GBASE_CR2_HALFM":127,
+"SFP28_25GBASE_CR1_HALFM":128,
+"SFPPLUS_8GBASE_FC_SW":129,
+"SFPPLUS_8GBASE_FC_LW":130,
+"SFPPLUS_16GBASE_FC_SW":131,
+"SFPPLUS_16GBASE_FC_LW":132,
+"QSFPPLUS_64GBASE_FC_SW4":133,
+"QSFPPLUS_4X16_16GBASE_FC_SW":134,
+"QSFPPLUS_64GBASE_FC_LW4":135,
+"QSFPPLUS_4X16_16GBASE_FC_LW":136,
+"QSFP28_128GBASE_FC_SW4":137,
+"QSFP28_4X32_32GBASE_FC_SW":138,
+"QSFP28_128GBASE_FC_LW4":139,
+"QSFP28_4X32_32GBASE_FC_LW":140,
+"SFP28_32GBASE_FC_SW":141,
+"SFP28_32GBASE_FC_LW":142,
+"SFP28_25GBASE_SR_NOF":143,
+"SFP28_25GBASE_eSR":144,
+"SFP28_25GBASE_LR":145,
+"SFP28_25GBASE_LR_LITE":146,
+"SFP28_25GBASE_SR_AOCXXM":147,
+"SFP28_25GBASE_CR1_LPBK":148,
+"QSFP28-DD_200GBASE_CR4_HALFM":149,
+"QSFP28-DD_200GBASE_CR4_1M":150,
+"QSFP28-DD_200GBASE_CR4_2M":151,
+"QSFP28-DD_200GBASE_CR4_3M":152,
+"QSFP28-DD_200GBASE_CR4_5M":153,
+"QSFP28-DD_200GBASE_CR4":154,
+"QSFP28-DD_200GBASE_CR4_1_HALFM":155,
+"QSFP28-DD_200GBASE_CR4_2_HALFM":156,
+"QSFP28-DD_2x100GBASE_CR4_1M":157,
+"QSFP28-DD_2x100GBASE_CR4_2M":158,
+"QSFP28-DD_2x100GBASE_CR4_3M":159,
+"QSFP28-DD_8x25GBASE_CR4_1M":160,
+"QSFP28-DD_8x25GBASE_CR4_2M":161,
+"QSFP28-DD_8x25GBASE_CR4_3M":162,
+"QSFP28-DD_200GBASE_CR4_LPBK":163,
+"SFPPLUS_10GBASE_CR_1_HALFM":164,
+"SFPPLUS_10GBASE_CR_2_HALFM":165,
+"SFPPLUS_10GBASE_CR_1M":166,
+"SFPPLUS_10GBASE_CR_2M":167,
+"SFPPLUS_10GBASE_CR_3M":168,
+"SFPPLUS_10GBASE_CR_4M":169,
+"SFPPLUS_10GBASE_CR_5M":170,
+"QSFP28-DD_200GBASE_SR4_HALFM":171,
+"QSFP28-DD_200GBASE_SR4_1M":172,
+"QSFP28-DD_200GBASE_SR4_2M":173,
+"QSFP28-DD_200GBASE_SR4_3M":174,
+"QSFP28-DD_200GBASE_SR4_5M":175,
+"QSFP28-DD_200GBASE_SR4":176,
+"QSFP28-DD_200GBASE_SR4_1_HALFM":177,
+"QSFP28-DD_200GBASE_SR4_2_HALFM":178,
+"1GBASE_COPPER":179,
+"10GBASE_COPPER":180,
+"25GBASE_BACKPLANE":181,
+"SFPPLUS_10GBASE_SR_AOC1M":182,
+"SFPPLUS_10GBASE_SR_AOC3M":183,
+"SFPPLUS_10GBASE_SR_AOC5M":184,
+"SFPPLUS_10GBASE_SR_AOC10M":185,
+"QSFPPLUS_4X10_10GBASE_SR_AOC10M":186,
+"QSFPPLUS_40GBASE_SR_AOC3M":187,
+"QSFPPLUS_40GBASE_SR_AOC5M":188,
+"QSFPPLUS_40GBASE_SR_AOC7M":189,
+"QSFPPLUS_40GBASE_SR_AOC10M":190,
+}
+
+def _fix_media_to_cps(data):
+    '''Fix ifspeed to CPS'''
+    return OUT_MEDIA_MAP[data]
+
+def _fix_media_from_cps(data):
+    '''Convert ifspeed to enum'''
+    return REV_MEDIA_MAP[data]
+
+REV_TAGGING_MODE_MAP = {1:"UNTAGGED",
+2:"TAGGED",
+3:"HYBRID",
+}
+OUT_TAGGING_MODE_MAP = {"UNTAGGED":1,
+"TAGGED":2,
+"HYBRID":3,
+}
+def _fix_tagging_mode_to_cps(data):
+    '''Fix ifspeed to CPS'''
+    return OUT_TAGGING_MODE_MAP[data]
+
+def _fix_tagging_mode_from_cps(data):
+    '''Convert ifspeed to enum'''
+    return REV_TAGGING_MODE_MAP[data]
+
+REV_LEARN_MODE_MAP = {1:"DROP",
+2:"DISABLE",
+3:"HW",
+4:"CPU_TRAP",
+5:"CPU_LOG",
+}
+OUT_LEARN_MODE_MAP = {"DROP":1,
+"DISABLE":2,
+"HW":3,
+"CPU_TRAP":4,
+"CPU_LOG":5,
+}
+
+def _fix_learn_mode_to_cps(data):
+    '''Fix ifspeed to CPS'''
+    return OUT_LEARN_MODE_MAP[data]
+
+def _fix_learn_mode_from_cps(data):
+    '''Convert ifspeed to enum'''
+    return REV_LEARN_MODE_MAP[data]
+
+REV_FEC_MAP = {1:"auto",
+2:"off",
+3:"cl91-rs",
+4:"cl74-fc",
+5:"cl108-rs",
+6:"not-supported",
+}
+OUT_FEC_MAP = {"auto":1,
+"off":2,
+"cl91-rs":3,
+"cl74-fc":4,
+"cl108-rs":5,
+"not-supported":6,
+}
+def _fix_fec_to_cps(data):
+    '''Fix ifspeed to CPS'''
+    return OUT_FEC_MAP[data]
+
+def _fix_fec_from_cps(data):
+    '''Convert ifspeed to enum'''
+    return REV_FEC_MAP[data]
+
+REV_BREAKOUT_MODE_MAP = {1:"DISABLED",
+2:"BREAKOUT_4x1",
+3:"BREAKOUT_2x1",
+4:"BREAKOUT_1x1"
+}
+OUT_BREAKOUT_MODE_MAP = {"DISABLED":1,
+"BREAKOUT_4x1":2,
+"BREAKOUT_2x1":3,
+"BREAKOUT_1x1":4
+}
+
+def _fix_breakout_mode_to_cps(data):
+    '''Fix ifspeed to CPS'''
+    return OUT_BREAKOUT_MODE_MAP[data]
+
+def _fix_breakout_mode_from_cps(data):
+    '''Convert ifspeed to enum'''
+    return REV_BREAKOUT_MODE_MAP[data]
+
+REV_CLEAR_COUNTERS = {1:"ALL",
+2:"ALL-ETH",
+3:"ALL-LAG",
+4:"ALL-VLAN",
+5:"ALL-LOOPBACK",
+6:"ALL-MGMT",
+7:"ALL-FC",
+}
+OUT_CLEAR_COUNTERS = {"ALL":1,
+"ALL-ETH":2,
+"ALL-LAG":3,
+"ALL-VLAN":4,
+"ALL-LOOPBACK":5,
+"ALL-MGMT":6,
+"ALL-FC":7
+}
+
+def _fix_clear_counters_to_cps(data):
+    '''Fix ifspeed to CPS'''
+    return OUT_CLEAR_COUNTERS[data]
+
+def _fix_clear_counters_from_cps(data):
+    '''Convert ifspeed to enum'''
+    return REV_CLEAR_COUNTERS[data]
+
+IN_MATCH_TYPE_MAP = {1:"SRC_IPV6", 
+2:"DST_IPV6", 
+3:"SRC_MAC", 
+4:"DST_MAC", 
+5:"SRC_IP", 
+6:"DST_IP", 
+7:"IN_PORTS", 
+8:"OUT_PORTS", 
+9:"IN_PORT", 
+10:"OUT_PORT", 
+11:"OUTER_VLAN_ID", 
+12:"OUTER_VLAN_PRI", 
+13:"OUTER_VLAN_CFI", 
+14:"INNER_VLAN_ID", 
+15:"INNER_VLAN_PRI", 
+16:"INNER_VLAN_CFI", 
+17:"L4_SRC_PORT", 
+18:"L4_DST_PORT", 
+19:"ETHER_TYPE", 
+20:"IP_PROTOCOL", 
+21:"DSCP", 
+22:"TTL", 
+23:"TOS", 
+24:"IP_FLAGS", 
+25:"TCP_FLAGS", 
+26:"IP_TYPE", 
+27:"IP_FRAG", 
+28:"IPV6_FLOW_LABEL", 
+29:"TC", 
+30:"ECN", 
+31:"ICMP_TYPE", 
+32:"ICMP_CODE", 
+33:"SRC_PORT", 
+34:"DST_PORT", 
+35:"NEIGHBOR_DST_HIT", 
+36:"ROUTE_DST_HIT", 
+37:"IN_INTFS", 
+38:"OUT_INTFS", 
+39:"IN_INTF", 
+40:"OUT_INTF", 
+41:"SRC_INTF", 
+42:"UDF", 
+43:"IPV6_NEXT_HEADER", 
+44:"RANGE_CHECK", 
+45:"FDB_DST_HIT", 
+}
+OUT_MATCH_TYPE_MAP = {"SRC_IPV6":1,
+"DST_IPV6":2,
+"SRC_MAC":3,
+"DST_MAC":4,
+"SRC_IP":5,
+"DST_IP":6,
+"IN_PORTS":7,
+"OUT_PORTS":8,
+"IN_PORT":9,
+"OUT_PORT":10,
+"OUTER_VLAN_ID":11,
+"OUTER_VLAN_PRI":12,
+"OUTER_VLAN_CFI":13,
+"INNER_VLAN_ID":14,
+"INNER_VLAN_PRI":15,
+"INNER_VLAN_CFI":16,
+"L4_SRC_PORT":17,
+"L4_DST_PORT":18,
+"ETHER_TYPE":19,
+"IP_PROTOCOL":20,
+"DSCP":21,
+"TTL":22,
+"TOS":23,
+"IP_FLAGS":24,
+"TCP_FLAGS":25,
+"IP_TYPE":26,
+"IP_FRAG":27,
+"IPV6_FLOW_LABEL":28,
+"TC":29,
+"ECN":30,
+"ICMP_TYPE":31,
+"ICMP_CODE":32,
+"SRC_PORT":33,
+"DST_PORT":34,
+"NEIGHBOR_DST_HIT":35,
+"ROUTE_DST_HIT":36,
+"IN_INTFS":37,
+"OUT_INTFS":38,
+"IN_INTF":39,
+"OUT_INTF":40,
+"SRC_INTF":41,
+"UDF":42,
+"IPV6_NEXT_HEADER":43,
+"RANGE_CHECK":44,
+"FDB_DST_HIT":45,
+}
+
+def _fix_match_type_to_cps(data):
+    '''Fix match type to CPS'''
+    return OUT_MATCH_TYPE_MAP[data]
+
+def _fix_match_type_from_cps(data):
+    '''Convert match type from CPS'''
+    return IN_MATCH_TYPE_MAP[data]
+
+IN_COUNTER_TYPE_MAP = {1:"PACKET", 
+2:"BYTE", 
+}
+OUT_COUNTER_TYPE_MAP = {"PACKET":1,
+"BYTE":2,
+}
+
+def _fix_counter_type_to_cps(data):
+    '''Fix counter type to CPS'''
+    return OUT_COUNTER_TYPE_MAP[data]
+
+def _fix_counter_type_from_cps(data):
+    '''Convert counter type from CPS'''
+    return IN_COUNTER_TYPE_MAP[data]
+
+
+IN_PACKET_ACTION_TYPE_MAP = {1:"DROP", 
+2:"FORWARD", 
+3:"COPY_TO_CPU", 
+4:"COPY_TO_CPU_CANCEL", 
+5:"TRAP_TO_CPU", 
+6:"COPY_TO_CPU_AND_FORWARD", 
+7:"COPY_TO_CPU_CANCEL_AND_DROP", 
+8:"COPY_TO_CPU_CANCEL_AND_FORWARD", 
+}
+OUT_PACKET_ACTION_TYPE_MAP = {"DROP":1,
+"FORWARD":2,
+"COPY_TO_CPU":3,
+"COPY_TO_CPU_CANCEL":4,
+"TRAP_TO_CPU":5,
+"COPY_TO_CPU_AND_FORWARD":6,
+"COPY_TO_CPU_CANCEL_AND_DROP":7,
+"COPY_TO_CPU_CANCEL_AND_FORWARD":8,
+}
+
+def _fix_packet_action_type_to_cps(data):
+    '''Fix packet action type to CPS'''
+    return OUT_PACKET_ACTION_TYPE_MAP[data]
+
+def _fix_packet_action_type_from_cps(data):
+    '''Convert packet action type from CPS'''
+    return IN_PACKET_ACTION_TYPE_MAP[data]
+
+IN_ACTION_TYPE_MAP = {1:"REDIRECT_PORT", 
+2:"REDIRECT_IP_NEXTHOP", 
+3:"PACKET_ACTION", 
+4:"FLOOD", 
+5:"MIRROR_INGRESS", 
+6:"MIRROR_EGRESS", 
+7:"SET_COUNTER", 
+8:"SET_POLICER", 
+9:"DECREMENT_TTL", 
+10:"SET_TC", 
+11:"SET_INNER_VLAN_ID", 
+12:"SET_INNER_VLAN_PRI", 
+13:"SET_OUTER_VLAN_ID", 
+14:"SET_OUTER_VLAN_PRI", 
+15:"SET_SRC_MAC", 
+16:"SET_DST_MAC", 
+17:"SET_SRC_IP", 
+18:"SET_DST_IP", 
+19:"SET_SRC_IPV6", 
+20:"SET_DST_IPV6", 
+21:"SET_DSCP", 
+22:"SET_L4_SRC_PORT", 
+23:"SET_L4_DST_PORT", 
+24:"SET_CPU_QUEUE", 
+25:"EGRESS_MASK", 
+26:"REDIRECT_PORT_LIST", 
+27:"REDIRECT_INTF", 
+28:"EGRESS_INTF_MASK", 
+29:"REDIRECT_INTF_LIST", 
+30:"SET_USER_TRAP_ID", 
+31:"SET_PACKET_COLOR", 
+}
+OUT_ACTION_TYPE_MAP = {"REDIRECT_PORT":1,
+"REDIRECT_IP_NEXTHOP":2,
+"PACKET_ACTION":3,
+"FLOOD":4,
+"MIRROR_INGRESS":5,
+"MIRROR_EGRESS":6,
+"SET_COUNTER":7,
+"SET_POLICER":8,
+"DECREMENT_TTL":9,
+"SET_TC":10,
+"SET_INNER_VLAN_ID":11,
+"SET_INNER_VLAN_PRI":12,
+"SET_OUTER_VLAN_ID":13,
+"SET_OUTER_VLAN_PRI":14,
+"SET_SRC_MAC":15,
+"SET_DST_MAC":16,
+"SET_SRC_IP":17,
+"SET_DST_IP":18,
+"SET_SRC_IPV6":19,
+"SET_DST_IPV6":20,
+"SET_DSCP":21,
+"SET_L4_SRC_PORT":22,
+"SET_L4_DST_PORT":23,
+"SET_CPU_QUEUE":24,
+"EGRESS_MASK":25,
+"REDIRECT_PORT_LIST":26,
+"REDIRECT_INTF":27,
+"EGRESS_INTF_MASK":28,
+"REDIRECT_INTF_LIST":29,
+"SET_USER_TRAP_ID":30,
+"SET_PACKET_COLOR":31,
+}
+
+def _fix_action_type_to_cps(data):
+    '''Fix action type to CPS'''
+    return OUT_ACTION_TYPE_MAP[data]
+
+def _fix_action_type_from_cps(data):
+    '''Convert action type from CPS'''
+    return IN_ACTION_TYPE_MAP[data]
+
+
+IN_MATCH_IP_FRAG_MAP = {1:"ANY", 
+2:"NON_FRAG", 
+3:"NON_FRAG_OR_HEAD", 
+4:"HEAD", 
+5:"NON_HEAD", 
+}
+OUT_MATCH_IP_FRAG_MAP = {"ANY":1,
+"NON_FRAG":2,
+"NON_FRAG_OR_HEAD":3,
+"HEAD":4,
+"NON_HEAD":5,
+}
+
+
+def _fix_match_ip_frag_to_cps(data):
+    '''Fix match ip frag type to CPS'''
+    return OUT_MATCH_IP_FRAG_MAP[data]
+
+def _fix_match_ip_frag_from_cps(data):
+    '''Convert match ip frag type from CPS'''
+    return IN_MATCH_IP_FRAG_MAP[data]
+
+
+IN_MATCH_IP_TYPE_MAP = {1:"ANY", 
+2:"IP", 
+3:"NON_IP", 
+4:"IPV4ANY", 
+5:"NON_IPV4", 
+6:"IPV6ANY", 
+7:"NON_IPV6", 
+8:"ARP", 
+9:"ARP_REQUEST", 
+10:"ARP_REPLY", 
+}
+OUT_MATCH_IP_TYPE_MAP = {"ANY":1,
+"IP":2,
+"NON_IP":3,
+"IPV4ANY":4,
+"NON_IPV4":5,
+"IPV6ANY":6,
+"NON_IPV6":7,
+"ARP":8,
+"ARP_REQUEST":9,
+"ARP_REPLY":10,
+}
+
+def _fix_ip_type_to_cps(data):
+    '''Fix ip type to CPS'''
+    return OUT_MATCH_IP_TYPE_MAP[data]
+
+def _fix_ip_type_from_cps(data):
+    '''Convert ip type from CPS'''
+    return IN_MATCH_IP_TYPE_MAP[data]
+
+
+IN_STAGE_MAP = {1:"INGRESS", 
+2:"EGRESS", 
+}
+OUT_STAGE_MAP = {"INGRESS":1,
+"EGRESS":2,
+}
+
+def _fix_stage_to_cps(data):
+    '''Fix stage to CPS'''
+    return OUT_STAGE_MAP[data]
+
+def _fix_stage_from_cps(data):
+    '''Convert stage from CPS'''
+    return IN_STAGE_MAP[data]
+
+
+IN_PACKET_COLOR_MAP = {1:"GREEN", 
+2:"YELLOW", 
+3:"RED"
+}
+OUT_PACKET_COLOR_MAP = {"GREEN":1,
+"YELLOW":2,
+"RED":3
+}
+
+def _fix_packet_color_to_cps(data):
+    '''Fix stage to CPS'''
+    return OUT_PACKET_COLOR_MAP[data]
+
+def _fix_packet_color_from_cps(data):
+    '''Convert stage from CPS'''
+    return IN_PACKET_COLOR_MAP[data]
+
+IN_RANGE_TYPE_MAP = {1:"L4_SRC_PORT", 
+2:"L4_DST_PORT", 
+3:"OUTER_VLAN", 
+4:"INNER_VLAN", 
+5:"PACKET_LENGTH", 
+}
+OUT_RANGE_TYPE_MAP = {"L4_SRC_PORT":1,
+"L4_DST_PORT":2,
+"OUTER_VLAN":3,
+"INNER_VLAN":4,
+"PACKET_LENGTH":5,
+}
+
+def _fix_range_type_to_cps(data):
+    '''Fix range type to CPS'''
+    return OUT_RANGE_TYPE_MAP[data]
+
+def _fix_range_type_from_cps(data):
+    '''Convert range type from CPS'''
+    return IN_RANGE_TYPE_MAP[data]
+
+DO_RANGE_TYPE = (_fix_range_type_to_cps, _fix_range_type_from_cps)
+DO_PACKET_COLOR = (_fix_packet_color_to_cps, _fix_packet_color_from_cps)
+DO_STAGE = (_fix_stage_to_cps, _fix_stage_from_cps)
+DO_IP_TYPE = (_fix_ip_type_to_cps, _fix_ip_type_from_cps)
+DO_IP_FRAG = (_fix_match_ip_frag_to_cps, _fix_match_ip_frag_from_cps)
+DO_ACTION_TYPE = (_fix_action_type_to_cps, _fix_action_type_from_cps)
+DO_PACKET_ACTION_TYPE = (_fix_packet_action_type_to_cps, _fix_packet_action_type_from_cps)
+DO_COUNTER_TYPE = (_fix_counter_type_to_cps, _fix_counter_type_from_cps)
+DO_MATCH_TYPE = (_fix_match_type_to_cps, _fix_match_type_from_cps)
+DO_FEC = (_fix_fec_to_cps, _fix_fec_from_cps)
+DO_LEARN_MODE = (_fix_learn_mode_to_cps, _fix_learn_mode_from_cps)
+DO_CLEAR_COUNTERS = (_fix_clear_counters_to_cps, _fix_clear_counters_from_cps)
+DO_BREAKOUT_MODE = (_fix_breakout_mode_to_cps, _fix_breakout_mode_from_cps)
+DO_TAGGING_MODE = (_fix_tagging_mode_to_cps, _fix_tagging_mode_from_cps)
+DO_MEDIA = (_fix_media_to_cps, _fix_media_from_cps)
+DO_SPEED = (_fix_speed_to_cps, _fix_speed_from_cps)
+DO_MODE = (_fix_mode_to_cps, _fix_mode_from_cps)
+DO_DUPLEX_TYPE = (_fix_duplex_type_to_cps, _fix_duplex_type_from_cps)
+DO_VLAN_TYPE = (_fix_vlan_type_to_cps, _fix_vlan_type_from_cps)
+DO_BOOL = (_bool_to_cps, _bool_from_cps)
+STRIP_MODULE = (_strip_module_to_cps, _strip_module_from_cps)
+FIX_IF_TYPE = (_fix_iftype_to_cps, _fix_iftype_from_cps)
+
+GLOBAL_MAP = TypeMap({'base-ip/ipv4/forwarding': DO_BOOL,
+           'dell-if/if/interfaces/interface/learning-mode':DO_BOOL,
+           'if/interfaces/interface/enabled':DO_BOOL,
+           'ietf-interfaces/interface/type':FIX_IF_TYPE,  # need to check this one, it may be surplus now
+           'if/interfaces/interface/type':FIX_IF_TYPE,
+           'dell-if/if/interfaces/interface/vlan-type':DO_VLAN_TYPE,
+           'dell-if/if/interfaces/interface/duplex':DO_DUPLEX_TYPE,
+           'dell-if/if/interfaces/interface/auto-negotiation':DO_BOOL,
+           'dell-if/if/interfaces/interface/mode':DO_MODE,
+           'dell-if/if/interfaces/interface/speed':DO_SPEED,
+           'base-if-phy/if/interfaces/interface/phy-media':DO_MEDIA,
+           'base-if-phy/if/interfaces/interface/tagging-mode':DO_TAGGING_MODE,
+           'base-if-phy/if/interfaces/interface/learn-mode':DO_LEARN_MODE,
+           'base-if-phy/breakout/fanout-mode':DO_BREAKOUT_MODE,
+           'base-if-phy/set-breakout-mode/breakout-mode':DO_BREAKOUT_MODE,
+           'dell-if/if/interfaces/interface/fec':DO_FEC,
+           'dell-if/clear-counters/all-intf':DO_CLEAR_COUNTERS,
+           'dell-if/clear-eee-counters/all-intf':DO_CLEAR_COUNTERS,
+           'base-acl/entry/match/IP_FRAG_VALUE':DO_IP_FRAG,
+           'base-acl/entry/match/type':DO_MATCH_TYPE,
+           'base-acl/entry/match/IP_PROTOCOL_VALUE':DO_MATCH_TYPE,
+           'base-acl/entry/match/IP_TYPE_VALUE':DO_IP_TYPE,
+#           'base-acl/entry/action/COUNTER_VALUE':DO_COUNTER_TYPE,
+           'base-acl/entry/action/type':DO_ACTION_TYPE,
+           })
+
+

--- a/python-inocybe-openswitch/inocybe_openswitch/tests/test_flatlandia.py
+++ b/python-inocybe-openswitch/inocybe_openswitch/tests/test_flatlandia.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+'''Path mapper test
+'''
+
+from inocybe_openswitch.flatlandia import build_list_item
+from inocybe_openswitch.flatlandia import build_result
+from inocybe_tree.pathmap import PathMap
+
+from nose.tools import ok_ as assert_
+from nose.tools import raises
+from nose.tools import assert_equal
+from nose.tools import assert_is_none
+
+RESULT_1 = \
+[
+    ["dell-base-if-cmn/if/interfaces/interface/if-index", 40],
+    ["dell-if/if/interfaces/interface/phys-address", "d2:0e:4c:e6:9a:25"],
+    ["base-if-vlan/if/interfaces/interface/id", 100],
+    ["if/interfaces/interface/name", "br100"],
+    ["dell-if/if/interfaces/interface/learning-mode", 1],
+    ["if/interfaces/interface/enabled", 0]
+]   
+
+RESULT_1_TOP_MAP = {"if":{"interfaces":{"interface":[{}]}}}
+RESULT_ELEMENT_MAP = \
+{
+    "interface": {
+        "if-index":{},
+        "phys-address":{},
+        "id":{},
+        "name":{},
+        "learning-mode":{},
+        "enabled":{}
+    }
+}
+
+def find_vec(array, vector):
+    '''Find if a vector is in an array'''
+    for row in array:
+        if vector[0] == row[0] and vector[1] == row[1]:
+            return True
+    return False
+
+def test_build_list_item():
+    '''The Earth is flat'''
+
+    # postulate that the earth is flat
+
+    assert_equal(len(build_list_item({'a':'b', 'c':'d'})), 2)
+    assert_(find_vec(build_list_item({'a':'b', 'c':'d'}), [['c'], 'd']))
+    assert_(find_vec(build_list_item({'a':'b', 'c':'d'}), [['c'], 'd']))
+    assert_(find_vec(build_list_item({'a':'b', 'c':'d'}), [['a'], 'b']))
+    # this one is actually testing the tester :)
+    assert_(not find_vec(build_list_item({'a':'b', 'c':'d'}), [['n'], 'n']))
+
+    # load the earth onto 4 elefants
+    assert_equal(len(build_list_item({'a':{'b':'e'}, 'c':'d'})), 2)
+    assert_(find_vec(build_list_item({'a':{'b':'e'}, 'c':'d'}), [['c'], 'd']))
+    assert_(find_vec(build_list_item({'a':{'b':'e'}, 'c':'d'}), [['a', 'b'], 'e']))
+    assert_equal(len(build_list_item({'a':{'b':{'e':'f'}}, 'c':'d'})) , 2)
+    assert_(find_vec(build_list_item({'a':{'b':{'e':'f'}}, 'c':'d'}), [['a', 'b','e'], 'f']))
+
+
+def test_build_result():
+    pm = PathMap()
+    pm.create(RESULT_ELEMENT_MAP)
+    result = build_result(RESULT_1, pm)
+
+    assert_equal(result['interface']['phys-address'], 'd2:0e:4c:e6:9a:25')
+    assert_equal(result['interface']['learning-mode'], 1)
+    assert_equal(result['interface']['id'], 100)
+    assert_equal(result['interface']['if-index'], 40)
+    assert_equal(result['interface']['enabled'], 0)
+    assert_equal(result['interface']['name'], 'br100')

--- a/python-inocybe-openswitch/models/acl-config.yang
+++ b/python-inocybe-openswitch/models/acl-config.yang
@@ -1,0 +1,78 @@
+module acl-config {
+    namespace "http://www.dellemc.com/networking/os10/dell-base-acl";
+    prefix "acl-config";
+
+
+    list entry {
+        key "name";
+
+        description "This element contains all of the created ACLs entry";
+
+        leaf name {
+            description "A user created field to identify the entry - if none provided one will be generated. ";
+            type string;
+        }
+
+	    leaf rule {
+            description "This holds the Access Control List (ACL) entry.  This field attempts to mimmic the standard
+                IP tables rules supporting the following switches:
+                -i, --in-interface name
+                    Input interface name - at this time must be a valid front panel port
+                -o, --out-interface name
+                    The output interface name - at this time must be a valid front panel port
+                -j, --jump target
+                    This can be one of the following two values.
+                    ACCEPT - the packet is accepted
+                    DROP - the packet will be dropped
+                -I chain rule-number
+                    Insert the rule into the specified chain at the rule-number location (rules are numberd from 1>).
+                    The supported chains are:
+                        INPUT packets entering the switch
+                        OUTPUT packets exiting the switch
+                --dport port
+                    The destination port
+                --sport port
+                    The source port
+                -p, --protocol protocol
+                    Filter based on a port or protocol.  The protocols that are supported are included in
+                    the /etc/protocols in addition to tcp, udp, icmp or all
+                -d, --destination address[/mask]
+                    The destination address which can be either IPv4/IPv6 or hostname
+                -s, --source address[/mask]
+                    The source address/mask of the packet which can be IPv4/IPv6 or a hostname
+                -m mac
+                    Load the MAC module.  The following two options are available after loading the MAC module
+                    --mac-source source-mac
+                        This combination loads the MAC module and enables MAC filtering on source addresses in the
+                        ethernet packet
+                    --mac-destination destion-mac
+                        This combination loads the MAC module and enables MAC filtering on destination addresses in the
+                        ethernet packet
+                 Examples:
+                     -A INPUT -p tcp --dport 80 -j ACCEPT
+                     -A INPUT -p tcp -m mac --mac-source 00:00:00:00:00:001 --dport 80 -j DROP
+                     -A INPUT -p tcp -m mac --mac-source 00:00:00:00:00:001 --dport 22 -j DROP
+                     ";
+            type string;
+        }
+
+
+    }
+    rpc reload {
+        description "This triggers a reload of the ACL configuration subsystem.  The filename specified will be loaded
+            and the differences applied";
+        input {
+            leaf filename {
+                type string;
+                description "The name of the file containing the input.";
+            }
+        }
+        output {
+            leaf result {
+                type string;
+                description "The result of the request which may be successful or a failure response.";
+            }
+        }
+    }
+
+}

--- a/python-inocybe-openswitch/models/base-acl.yang
+++ b/python-inocybe-openswitch/models/base-acl.yang
@@ -1,0 +1,1837 @@
+module base-acl {
+
+    namespace "http://www.dellemc.com/networking/os10/dell-base-acl";
+    prefix "base-acl";
+
+    import ietf-inet-types {
+        prefix "inet";
+    }
+
+    import base-common {
+        prefix "base-cmn";
+    }
+
+    import ietf-yang-types {
+        prefix "yang";
+    }
+
+    import ietf-interfaces {
+        prefix "if";
+    }
+
+    organization
+        "Dell EMC";
+
+    contact
+        "http://www.dell.com/support";
+
+    description
+        "This module contains a collection of YANG definitions
+         for managing Access Control Lists (ACLs).
+
+         Copyright (c) 2015-2016 by Dell EMC,
+         All rights reserved.";
+
+    revision 2014-12-01 {
+        description "Initial revision";
+    }
+
+    typedef udf-match-bytes {
+        type binary {
+            length "16";
+        }
+    }
+
+    typedef counter-type {
+        type enumeration {
+            enum PACKET {
+              value 1;
+            }
+            enum BYTE {
+              value 2;
+            }
+        }
+    }
+
+    typedef match-type {
+        description "Enumeration of all possible packet fields that can be
+                     used to match packets.";
+
+        type enumeration {
+            enum SRC_IPV6 {
+              value 1;
+                description "Match based on Src IPv6 Address";
+            }
+
+            enum DST_IPV6 {
+              value 2;
+                description "Match based on Dst IPv6 Address";
+            }
+
+            enum SRC_MAC {
+              value 3;
+                description "Match based on Src MAC Address";
+            }
+
+            enum DST_MAC {
+              value 4;
+                description "Match based on Dst MAC Address";
+            }
+
+            enum SRC_IP {
+              value 5;
+                description "Match based on Src IPv4 Address";
+            }
+
+            enum DST_IP {
+              value 6;
+                description "Match based on Dst IPv4 Address";
+            }
+
+            enum IN_PORTS {
+              value 7;
+                description "Match packets incoming on any of the specified list of Ports";
+              status obsolete;
+            }
+
+            enum OUT_PORTS {
+              value 8;
+                description "Match packets outgoing on any of the specified list of Ports";
+              status obsolete;
+            }
+
+            enum IN_PORT {
+              value 9;
+                description "Match packets incoming on specified Port";
+              status obsolete;
+            }
+
+            enum OUT_PORT {
+              value 10;
+                description "Match packets outgoing on specified Port";
+              status obsolete;
+            }
+
+            enum OUTER_VLAN_ID {
+              value 11;
+                description "Match based on Outer Vlan-Id";
+            }
+
+            enum OUTER_VLAN_PRI {
+              value 12;
+                description "Match based on Outer Vlan-Priority";
+            }
+
+            enum OUTER_VLAN_CFI {
+              value 13;
+                description "Match based on Outer Vlan CFI or DEI bit";
+            }
+
+            enum INNER_VLAN_ID {
+              value 14;
+                description "Match based on Inner Vlan-Id";
+            }
+
+            enum INNER_VLAN_PRI {
+              value 15;
+                description "Match based on Inner Vlan-Priority";
+            }
+
+            enum INNER_VLAN_CFI {
+              value 16;
+                description "Match based on Inner Vlan CFI or DEI bit";
+            }
+
+            enum L4_SRC_PORT {
+              value 17;
+                description "Match based on L4 Src Port";
+            }
+
+            enum L4_DST_PORT {
+              value 18;
+                description "Match based on L4 Dst Port";
+            }
+
+            enum ETHER_TYPE {
+              value 19;
+                description "Match based on EtherType";
+            }
+
+            enum IP_PROTOCOL {
+              value 20;
+                description "Match based on IP Protocol";
+            }
+
+            enum DSCP {
+              value 21;
+                description "Match based on Ip Dscp";
+            }
+
+            enum TTL {
+              value 22;
+                description "Match based on Ip Ttl";
+            }
+
+            enum TOS {
+              value 23;
+                description "Match based on Ip Tos";
+            }
+
+            enum IP_FLAGS {
+              value 24;
+                description "Match based on Ip Flags";
+            }
+
+            enum TCP_FLAGS {
+              value 25;
+                description "Match based on Tcp Flags";
+            }
+
+            enum IP_TYPE {
+              value 26;
+                description "Match based on Packet type - IPv4 or IPv6 or ARP";
+            }
+
+            enum IP_FRAG {
+              value 27;
+                description "Match based on IP Fragment";
+            }
+
+            enum IPV6_FLOW_LABEL {
+              value 28;
+                description "Match based on IPv6 Flow label";
+            }
+
+            enum TC {
+              value 29;
+                description "Match packets by the QoS Traffic Class assigned to them";
+            }
+
+            enum ECN {
+              value 30;
+                description "Match based on IP ECN bits";
+            }
+
+            enum ICMP_TYPE {
+              value 31;
+                description "Match based on ICMP Type field";
+            }
+
+            enum ICMP_CODE {
+              value 32;
+                description "Match based on ICMP Code field";
+            }
+
+            enum SRC_PORT {
+              value 33;
+                description "Match packets incoming on specified Port or LAG";
+              status obsolete;
+            }
+
+            enum DST_PORT {
+              value 34;
+                description "Match packets outgoing on specified Port or LAG";
+              status obsolete;
+            }
+
+            enum NEIGHBOR_DST_HIT {
+              value 35;
+                description "Packet destination IP address match in neighbor table";
+            }
+
+            enum ROUTE_DST_HIT {
+              value 36;
+                description "Packet destination IP address match in routing table";
+            }
+
+            enum IN_INTFS {
+              value 37;
+                description "Match packets incoming on any of the specified list of Interfaces";
+            }
+
+            enum OUT_INTFS {
+              value 38;
+                description "Match packets outgoing on any of the specified list of Interfaces";
+            }
+
+            enum IN_INTF {
+              value 39;
+                description "Match packets incoming on specified Interface";
+            }
+
+            enum OUT_INTF {
+              value 40;
+                description "Match packets outgoing on specified Interface";
+            }
+
+            enum SRC_INTF {
+              value 41;
+                description "Match packets incoming on specified Front-panel or LAG interface";
+            }
+
+            enum UDF {
+              value 42;
+                description "Match packets based on UDF byte list";
+            }
+
+            enum IPV6_NEXT_HEADER {
+              value 43;
+                description "Match IPv6 packets based on next header byte";
+            }
+
+            enum RANGE_CHECK {
+              value 44;
+                description "Match based on range settings";
+            }
+
+            enum FDB_DST_HIT {
+              value 45;
+                description "Packet destination MAC address match in FDB";
+            }
+        }
+    }
+
+    typedef packet-action-type {
+        description "Enumeration of packet actions";
+
+        type enumeration {
+            enum DROP {
+              value 1;
+                description "Do NOT forward packet in the data path (does not
+                             affect CPU copy behavior)";
+            }
+
+            enum FORWARD {
+              value 2;
+                description "Forward Packet in the data path - overrides lower
+                             priority DROP action (does not affect CPU copy
+                             behavior)";
+            }
+
+            enum COPY_TO_CPU {
+              value 3;
+                description "Copy Packet to CPU (does not affect data path
+                             forwarding behavior)";
+            }
+
+            enum COPY_TO_CPU_CANCEL {
+              value 4;
+                description "Overrides lower priority Copy Packet to CPU action
+                             (does not affect data path forwarding behavior)";
+            }
+
+            enum TRAP_TO_CPU {
+              value 5;
+                description "Copy Packet to CPU + Drop";
+            }
+
+            enum COPY_TO_CPU_AND_FORWARD {
+              value 6;
+                description "Copy Packet to CPU + Forward";
+            }
+
+            enum COPY_TO_CPU_CANCEL_AND_DROP {
+              value 7;
+                description "Copy Packet to CPU Cancel + Drop";
+            }
+
+            enum COPY_TO_CPU_CANCEL_AND_FORWARD {
+              value 8;
+                description "Copy Packet to CPU Cancel + Forward";
+            }
+        }
+    }
+
+    typedef action-type {
+        description "Enumeration of all possible actions that can be performed
+            on matched packets in a acl entry.";
+
+        type enumeration {
+
+            enum REDIRECT_PORT {
+              value 1;
+                description "Redirect Packet to Port or LAG (Link Aggregated Trunk).";
+              status obsolete;
+            }
+
+            enum REDIRECT_IP_NEXTHOP {
+              value 2;
+                description "Redirect Packet to NextHop";
+            }
+
+            enum PACKET_ACTION {
+              value 3;
+                description "Drop, Forward and Trap or Copy to CPU";
+            }
+
+            enum FLOOD {
+              value 4;
+                description "Flood Packet to all ports in Vlan";
+            }
+
+            enum MIRROR_INGRESS {
+              value 5;
+                description "Ingress Mirror";
+            }
+
+            enum MIRROR_EGRESS {
+              value 6;
+                description "Egress Mirror";
+            }
+
+            enum SET_COUNTER {
+              value 7;
+                description "Associate Counter for ACL entry hit stats";
+            }
+
+            enum SET_POLICER {
+              value 8;
+                description "Assosiate with policer";
+            }
+
+            enum DECREMENT_TTL {
+              value 9;
+                description "Decrement TTL";
+            }
+
+            enum SET_TC {
+              value 10;
+                 description "Assign a new QoS Traffic class for the packet";
+            }
+
+            enum SET_INNER_VLAN_ID {
+              value 11;
+                description "Set Packet Inner Vlan-Id";
+            }
+
+            enum SET_INNER_VLAN_PRI {
+              value 12;
+                description "Set Packet Inner Vlan-Priority";
+            }
+
+            enum SET_OUTER_VLAN_ID {
+              value 13;
+                description "Set Packet Outer Vlan-Id";
+            }
+
+            enum SET_OUTER_VLAN_PRI {
+              value 14;
+                description "Set Packet Outer Vlan-Priority";
+            }
+
+            enum SET_SRC_MAC {
+              value 15;
+                description "Set Packet Src MAC Address";
+            }
+
+            enum SET_DST_MAC {
+              value 16;
+                description "Set Packet Dst MAC Address";
+            }
+
+            enum SET_SRC_IP {
+              value 17;
+                description "Set Packet Src IPv4 Address";
+            }
+
+            enum SET_DST_IP {
+              value 18;
+                description "Set Packet Src IPv4 Address";
+            }
+
+            enum SET_SRC_IPV6 {
+              value 19;
+                description "Set Packet Src IPv6 Address";
+            }
+
+            enum SET_DST_IPV6 {
+              value 20;
+                description "Set Packet Src IPv6 Address";
+            }
+
+            enum SET_DSCP {
+              value 21;
+                description "Set Packet DSCP";
+            }
+
+            enum SET_L4_SRC_PORT {
+              value 22;
+                description "Set Packet L4 Src Port";
+            }
+
+            enum SET_L4_DST_PORT {
+              value 23;
+                description "Set Packet L4 Src Port";
+            }
+
+            enum SET_CPU_QUEUE {
+              value 24;
+                description "Select the CPU queue for packets sent to CPU Port";
+            }
+
+            enum EGRESS_MASK {
+              value 25;
+                description "Block packets that are destined to the given port list";
+              status obsolete;
+            }
+
+            enum REDIRECT_PORT_LIST {
+              value 26;
+                description "Redirect packets to the given port list";
+              status obsolete;
+            }
+
+            enum REDIRECT_INTF {
+              value 27;
+                description "Redirect Packet to Front panel or LAG (Link Aggregated Trunk).";
+            }
+
+            enum EGRESS_INTF_MASK {
+              value 28;
+                description "Block packets that are destined to the given interface list";
+            }
+
+            enum REDIRECT_INTF_LIST {
+              value 29;
+                description "Redirect packets to the given interface list";
+            }
+
+            enum SET_USER_TRAP_ID {
+              value 30;
+                description "Set user defined trap id";
+            }
+            enum SET_PACKET_COLOR {
+              value 31;
+                description "Set packet color";
+            }
+        }
+    }
+
+    typedef match-ip-frag {
+        type enumeration {
+            enum ANY {
+              value 1;
+                description "Any Fragment of Fragmented Packet";
+            }
+
+            enum NON_FRAG {
+              value 2;
+                description "Non-Fragmented Packet";
+            }
+
+            enum NON_FRAG_OR_HEAD {
+              value 3;
+                description "Non-Fragmented or First Fragment";
+            }
+
+            enum HEAD {
+              value 4;
+                description "First Fragment of Fragmented Packet";
+            }
+
+            enum NON_HEAD {
+              value 5;
+                description "Not the First Fragment";
+            }
+        }
+    }
+
+    typedef match-ip-type {
+        type enumeration {
+            enum ANY {
+              value 1;
+                description "Don't care";
+            }
+
+            enum IP {
+              value 2;
+                description "IPv4 and IPv6 packets";
+            }
+
+            enum NON_IP {
+              value 3;
+                description "Non-Ip packet";
+            }
+
+            enum IPV4ANY {
+              value 4;
+                description "Any IPv4 packet";
+            }
+
+            enum NON_IPV4 {
+              value 5;
+                description "Anything but IPv4 packets";
+            }
+
+            enum IPV6ANY {
+              value 6;
+                description "IPv6 packet";
+            }
+
+            enum NON_IPV6 {
+              value 7;
+                description "Anything but IPv6 packets";
+            }
+
+            enum ARP {
+              value 8;
+                description "ARP/RARP";
+            }
+
+            enum ARP_REQUEST {
+              value 9;
+                description "ARP Request";
+            }
+
+            enum ARP_REPLY {
+              value 10;
+                description "ARP Reply";
+            }
+        }
+    }
+
+    typedef stage {
+        type enumeration {
+            enum INGRESS {
+              value 1;
+                description "Ingress Stage";
+            }
+            enum EGRESS {
+              value 2;
+                description "Egress Stage";
+            }
+        }
+    }
+
+    typedef vlan-dot1p-field {
+        type uint8 {range "0..7";}
+    }
+
+    typedef vlan-cfi-field {
+        type uint8 {range "0..1";}
+    }
+
+    typedef packet-color {
+        type enumeration {
+            enum GREEN {
+                value "1";
+                description "Green";
+            }
+            enum YELLOW {
+                value "2";
+                description "Yellow";
+            }
+            enum RED {
+                value "3";
+                description "Red";
+            }
+        }
+    }
+
+    grouping ipv6-match {
+        leaf addr {
+            mandatory true;
+            type inet:ipv6-address;
+        }
+        leaf mask {
+            mandatory true;
+            type inet:ipv6-address;
+        }
+    }
+
+    grouping mac-match {
+        leaf addr {
+            mandatory true;
+            type yang:mac-address;
+        }
+        leaf mask {
+            mandatory true;
+            type yang:mac-address;
+        }
+    }
+
+    grouping ipv4-match {
+        leaf addr {
+            mandatory true;
+            type inet:ipv4-address;
+        }
+        leaf mask {
+            mandatory true;
+            type inet:ipv4-address;
+        }
+    }
+
+    grouping uint32-match {
+        leaf data {
+            mandatory "true";
+            type uint32;
+        }
+        leaf mask {
+            type uint32;
+        }
+    }
+
+    grouping uint16-match {
+        leaf data {
+            mandatory "true";
+            type uint16;
+        }
+        leaf mask {
+            type uint16;
+        }
+    }
+
+    grouping uint8-match {
+        leaf data {
+            mandatory "true";
+            type uint8;
+        }
+        leaf mask {
+            type uint8;
+        }
+    }
+
+    grouping udf-match {
+        leaf udf-group-id {
+            mandatory "true";
+            type base-cmn:base-obj-id-type;
+        }
+        leaf match-data {
+            mandatory "true";
+            type udf-match-bytes;
+        }
+        leaf match-mask {
+            type udf-match-bytes;
+        }
+    }
+
+    grouping mirror-value {
+        leaf index {
+            type uint32;
+            mandatory "true";
+            description
+                "Refers to the Mirror session entry
+                defined in Mirroring data model.
+                Yang Ref:  dell-base-mirror/entry/id
+                Multiple ACL entries can refer to the
+                same mirroring session.";
+        }
+
+        leaf data {
+            type base-cmn:mirror-opaque-data;
+            mandatory "true";
+            description
+                "Opaque blob containing hardware specific mirroring data.
+                Yang Ref:  dell-base-mirror/entry/opaque-data
+                To get the opaque data, the Application needs to do a
+                GET operation on the above Mirroring attribute
+                only AFTER a successful Observed state change is published
+                for the Mirroring configuration.
+                NOTE: The Application has to perform this GET every time
+                the Mirroring session is configured on a new NPU.
+                It then needs to pass this blob as an attribute to the
+                ACL Entry object.";
+        }
+    }
+
+    grouping match-parameters
+    {
+        leaf type {
+            type match-type;
+        }
+
+        /**** Possible Match values -
+         *  Specify ONLY ONE of these depending on the match type
+         */
+        container SRC_IPV6_VALUE {
+            description "Value for Src IPv6 Address";
+            when "../type = SRC_IPV6";
+            uses ipv6-match;
+        }
+
+        container DST_IPV6_VALUE {
+            description "Value for Dest IPv6 Address";
+            when "../type = DST_IPV6";
+            uses ipv6-match;
+        }
+
+        container SRC_MAC_VALUE {
+            description "Value for Src MAC Address";
+            when "../type = SRC_MAC";
+            uses mac-match;
+        }
+
+        container DST_MAC_VALUE {
+            description "Value for Dst MAC Address";
+            when "../type = DST_MAC";
+            uses mac-match;
+        }
+
+        container SRC_IP_VALUE {
+            description "Value for Src IPv4 Address";
+            when "../type = SRC_IP";
+            uses ipv4-match;
+        }
+
+        container DST_IP_VALUE {
+            description "Value for Dst IPv4 Address";
+            when "../type = DST_IP";
+            uses ipv4-match;
+        }
+
+        leaf-list IN_PORTS_VALUE {
+            when "../type = IN_PORTS";
+            description
+                "This field does not refer to a packet field.
+                Its presence means that this Acl-Entry should
+                ONLY be applied to packets that are received
+                from any 1 of the ports specified in this list.";
+            type base-cmn:logical-ifindex;
+            status obsolete;
+        }
+
+        leaf-list OUT_PORTS_VALUE {
+            when "../type = OUT_PORTS";
+            description
+                "This field does not refer to a packet field.
+                Its presence means that this Acl-Entry should
+                ONLY be applied to packets that will be
+                transmitted out on any 1 of the ports specified
+                in this list.";
+            type base-cmn:logical-ifindex;
+            status obsolete;
+        }
+
+        leaf IN_PORT_VALUE {
+            when "../type = IN_PORT";
+            description
+                "This field does not refer to a packet field.
+                Its presence means that this Acl-Entry should
+                ONLY be applied to packets that are received
+                from the port specified.";
+            type base-cmn:logical-ifindex;
+            status obsolete;
+        }
+
+        leaf OUT_PORT_VALUE {
+            when "../type = OUT_PORT";
+            description
+                "This field does not refer to a packet field.
+                Its presence means that this Acl-Entry should
+                ONLY be applied to packets that will be
+                transmitted out on the port specified.";
+            type base-cmn:logical-ifindex;
+            status obsolete;
+        }
+
+        container OUTER_VLAN_ID_VALUE {
+            when "../type = OUTER_VLAN_ID";
+            uses uint16-match;
+            description
+                "This field should be matched against the 12 LSB
+                 bits of the IEEE 802.1Q Vlan tag in the packet.
+                 Valid range: 1-4095 inclusive";
+        }
+        container OUTER_VLAN_PRI_VALUE {
+            when "../type = OUTER_VLAN_PRI";
+            uses uint8-match;
+            description
+                "This field should be matched against the 3 MSB
+                 bits of the IEEE 802.1Q Vlan tag in the packet.
+                 Valid range: 0-7 inclusive";
+        }
+        leaf OUTER_VLAN_CFI_VALUE {
+            when "../type = OUTER_VLAN_CFI";
+            type vlan-cfi-field;
+            description
+                "This field should be matched against the 4th MSB
+                bit of the IEEE 802.1Q Vlan tag in the packet.";
+        }
+
+        container INNER_VLAN_ID_VALUE {
+            when "../type = INNER_VLAN_ID";
+            uses uint16-match;
+            description
+                "This field should be matched against the 12 LSB
+                 bits of the inner IEEE 802.1Q Vlan tag in a
+                 double tagged packet.
+                 Valid range: 1-4095 inclusive";
+        }
+        container INNER_VLAN_PRI_VALUE {
+            when "../type = INNER_VLAN_PRI";
+            uses uint8-match;
+            description
+                "This field should be matched against the 3 MSB
+                 bits of the inner IEEE 802.1Q Vlan tag in a
+                 double tagged packet.
+                 Valid range: 0-7 inclusive";
+        }
+        leaf INNER_VLAN_CFI_VALUE {
+            when "../type = INNER_VLAN_CFI";
+            type vlan-cfi-field;
+            description
+                "This field should be matched against the 4th MSB
+                bit of the inner IEEE 802.1Q Vlan tag in a
+                double tagged packet.";
+        }
+
+        container L4_SRC_PORT_VALUE {
+            when "../type = L4_SRC_PORT";
+            description "Value of L4 Source Port to match";
+            uses uint16-match;
+        }
+
+        container L4_DST_PORT_VALUE {
+            when "../type = L4_DST_PORT";
+            description "Value of L4 Dest Port to match";
+            uses uint16-match;
+        }
+
+        container ETHER_TYPE_VALUE {
+            description "Value for EtherType";
+            when "../type = ETHER_TYPE";
+            uses uint16-match;
+        }
+
+        container IP_PROTOCOL_VALUE {
+            when "../type = IP_PROTOCOL";
+            uses uint8-match;
+            description
+                "Match packets with given value in IP Protocol field";
+        }
+
+        container DSCP_VALUE {
+            when "../type = DSCP";
+            uses uint8-match;
+            description
+                "Match packets with given dscp value.
+                 Valid range: 0-63 inclusive";
+        }
+
+        container TTL_VALUE {
+            description "Value for Ip Ttl";
+            when "../type = TTL";
+            uses uint8-match;
+        }
+
+        container TOS_VALUE {
+            description "Value for Ip Tos";
+            when "../type = TOS";
+            uses uint8-match;
+        }
+
+        container IP_FLAGS_VALUE {
+            description "Value for Ip Flags.
+                         Valid range: 0-63 inclusive";
+            when "../type = IP_FLAGS";
+            uses uint8-match;
+        }
+
+        container TCP_FLAGS_VALUE {
+            description "Value for Tcp Flags";
+            when "../type = TCP_FLAGS";
+            uses uint8-match;
+        }
+
+        leaf IP_TYPE_VALUE {
+            when "../type = IP_TYPE";
+            type match-ip-type;
+        }
+
+        leaf IP_FRAG_VALUE {
+            when "../type = IP_FRAG";
+            type match-ip-frag;
+        }
+
+        container IPV6_FLOW_LABEL_VALUE {
+            when "../type = IPV6_FLOW_LABEL";
+            uses uint32-match;
+            description "Value for Ipv6 Flow label.
+                         Valid range: 0x0-0xfffff inclusive";
+        }
+
+        container TC_VALUE {
+            description
+                "Match packets based on the QoS Traffic class assigned to them";
+            when "../type = TC";
+            uses uint8-match;
+        }
+
+        container ECN_VALUE {
+            when "../type = ECN";
+            uses uint8-match;
+            description "Value for ECN.
+                         Valid range: 0-3 inclusive";
+        }
+
+        container ICMP_TYPE_VALUE {
+            when "../type = ICMP_TYPE";
+            uses uint8-match;
+            description "Value for ICMP Type.";
+        }
+
+        container ICMP_CODE_VALUE {
+            when "../type = ICMP_CODE";
+            uses uint8-match;
+            description "Value for ICMP Code.";
+        }
+
+        leaf SRC_PORT_VALUE {
+            when "../type = SRC_PORT";
+            description
+                "This field does not refer to a packet field.
+                Its presence means that this Acl-Entry should
+                ONLY be applied to packets that are received
+                from the port specified.";
+            type base-cmn:logical-ifindex;
+            status obsolete;
+        }
+
+        leaf DST_PORT_VALUE {
+            when "../type = DST_PORT";
+            description
+                "This field does not refer to a packet field.
+                Its presence means that this Acl-Entry should
+                ONLY be applied to packets that will be
+                transmitted out on the port specified.";
+            type base-cmn:logical-ifindex;
+            status obsolete;
+        }
+
+        leaf-list IN_INTFS_VALUE {
+            when "../type = IN_INTFS";
+            description
+                "This field does not refer to a packet field.
+                Its presence means that this Acl-Entry should
+                ONLY be applied to packets that are received
+                from any 1 of the ports specified in this list.";
+            type if:interface-ref;
+        }
+
+        leaf-list OUT_INTFS_VALUE {
+            when "../type = OUT_INTFS";
+            description
+                "This field does not refer to a packet field.
+                Its presence means that this Acl-Entry should
+                ONLY be applied to packets that will be
+                transmitted out on any 1 of the ports specified
+                in this list.";
+            type if:interface-ref;
+        }
+
+        leaf IN_INTF_VALUE {
+            when "../type = IN_INTF";
+            description
+                "This field does not refer to a packet field.
+                Its presence means that this Acl-Entry should
+                ONLY be applied to packets that are received
+                from the port specified.";
+            type if:interface-ref;
+        }
+
+        leaf OUT_INTF_VALUE {
+            when "../type = OUT_INTF";
+            description
+                "This field does not refer to a packet field.
+                Its presence means that this Acl-Entry should
+                ONLY be applied to packets that will be
+                transmitted out on the port specified.";
+            type if:interface-ref;
+        }
+
+        leaf SRC_INTF_VALUE {
+            when "../type = SRC_INTF";
+            description
+                "This field does not refer to a packet field.
+                Its presence means that this Acl-Entry should
+                ONLY be applied to packets that are received
+                from the port specified.";
+            type if:interface-ref;
+        }
+
+        container UDF_VALUE {
+            when "../type = UDF";
+            uses udf-match;
+            description "Value for UDF byte array.";
+        }
+
+        container IPV6_NEXT_HEADER_VALUE {
+            when "../type = IPV6_NEXT_HEADER";
+            uses uint8-match;
+            description "Value for IPv6 next header byte.";
+        }
+
+        leaf-list RANGE_CHECK_VALUE {
+            when "../type = RANGE_CHECK";
+            type base-cmn:base-obj-id-type;
+            description "List of ACL range checker IDs.";
+        }
+        leaf NEIGHBOR_DST_HIT_VALUE {
+            when "../type = NEIGHBOR_DST_HIT";
+            type boolean;
+            description "Value to specify packet destination IP address match or not match in
+                         neighbor table";
+        }
+
+        leaf ROUTE_DST_HIT_VALUE {
+            when "../type = ROUTE_DST_HIT";
+            type boolean;
+            description "Value to specify packet destination IP address match or not match in
+                         routing table";
+        }
+
+        leaf FDB_DST_HIT_VALUE {
+            when "../type = FDB_DST_HIT";
+            type boolean;
+            description "Value to specify packet destination MAC address match or not match FDB";
+        }
+    }
+
+    grouping action-parameters {
+        leaf type {
+            type action-type;
+        }
+
+        /**** Possible Action values -
+         *  Specify ONLY ONE of these depending on the Action type
+         */
+
+        leaf REDIRECT_PORT_VALUE {
+            type base-cmn:logical-ifindex;
+            description "Port or LAG trunk to Redirect Packet on";
+            when "../type = REDIRECT_PORT";
+            status obsolete;
+        }
+
+        leaf REDIRECT_VLAN_VALUE {
+            type base-cmn:vlan-id;
+            description "Vlan to Redirect Packet on";
+            when "../type = REDIRECT_VLAN";
+        }
+
+        container IP_NEXTHOP_GROUP_VALUE {
+            description "This refers to the next-hop group id
+                defined in the Routing data model. Packets will be
+                redirected to the next-hop router referred by
+                this group-id.";
+            when "../type = REDIRECT_IP_NEXTHOP";
+
+            leaf id {
+                type uint32;
+                description
+                    "Refers to the Next-Hop group entry defined in the
+                     Routing data model. Multiple ACL entries can refer
+                     to the same next-hop group ID.";
+                status obsolete;
+            }
+
+            leaf vrf_id {
+                type uint32;
+                mandatory "true";
+                description "VRF ID";
+            }
+
+            leaf af {
+                type base-cmn:af-type;
+                mandatory "true";
+                description "Address Family";
+            }
+
+            leaf dest-addr {
+                type inet:ip-address;
+                mandatory "true";
+                description "Route/Nexthop address to be tracked";
+            }
+
+            leaf data {
+                type base-cmn:ip-nexthop-group-opaque-data;
+                mandatory "true";
+                description
+                    "Opaque blob containing hardware specific data for
+                     the Next-Hop Group defined in the Routing data model.";
+            }
+        }
+
+        leaf PACKET_ACTION_VALUE {
+            when "../type = PACKET_ACTION";
+            type packet-action-type;
+            description "Drop or allow or copy packet to CPU";
+        }
+
+        list MIRROR_INGRESS_VALUE {
+            when "../type = MIRROR_INGRESS";
+            key index;
+            uses mirror-value;
+            description "This refers to the mirroring session defined
+                         in the mirroring data model. It can take a
+                         list of ingress mirroring sessions.
+                         To add/remove sessions to an existing Mirroring action
+                         the entire modified list needs to be provided.
+                         The existing action will be overwritten with the
+                         new list of mirroring sessions.";
+        }
+
+        list MIRROR_EGRESS_VALUE {
+            when "../type = MIRROR_EGRESS";
+            key index;
+            uses mirror-value;
+            description "This refers to the mirroring session defined
+                         in the mirroring data model. It can take a
+                         list of egress mirroring sessions.
+                         To add/remove sessions to an existing Mirroring action
+                         the entire modified list needs to be provided.
+                         The existing action will be overwritten with the
+                         new list of mirroring sessions.";
+        }
+
+        leaf COUNTER_VALUE {
+            when "../type = SET_COUNTER";
+            type base-cmn:base-obj-id-type;
+            description "This refers to the ACL counter object id
+                         Yang Ref: dell-base-acl/counter/id.
+                         This counter should belong to the same ACL Table
+                         as the Entry";
+        }
+
+        container POLICER_VALUE {
+            when "../type = SET_POLICER";
+            leaf index {
+                type base-cmn:base-obj-id-type;
+                mandatory "true";
+                description "Refers to the policer entry
+                    defined in QoS data model.
+                    Yang Ref: dell-base-qos/meter/id.
+                    Multiple ACL entries can refer to the
+                    same policer in which case packets
+                    matching all those ACL entries are
+                    cumulatively metered to the
+                    specified rate.";
+            }
+
+            leaf data {
+                type base-cmn:qos-meter-opaque-data;
+                mandatory "true";
+                description
+                    "Opaque blob containing hardware specific meter data.
+                    Yang Ref: dell-base-qos/meter/data.
+                    To get the opaque data, the Application needs to do a
+                    GET operation on the above QoS Meter attribute
+                    only AFTER a successful Observed state change is
+                    published for the Meter configuration.
+                    The Application has to perform this GET every time
+                    the Meter is configured on a new NPU.
+                    It then needs to pass this blob as an attribute
+                    to the ACL Entry object.
+                    Dependency - The Meter should have been successfully
+                    configured on all the NPUs specified in the ACL
+                    entry";
+            }
+        }
+
+        leaf NEW_TC_VALUE {
+            when "../type = SET_TC";
+            type base-cmn:traffic-class;
+            description
+                "New QoS Traffic Class value to be assigned to packets
+                 matching this ACL entry. This determines the type
+                 of Quality of Service this packet receives at egress";
+        }
+
+        leaf NEW_INNER_VLAN_ID_VALUE {
+            description "Value for action Set Packet Inner Vlan-Id.
+                         Valid range: 1-4095 inclusive";
+            when "../type = SET_INNER_VLAN_ID";
+            type base-cmn:vlan-id;
+        }
+
+        leaf NEW_INNER_VLAN_PRI_VALUE {
+            description "Value for action Mark Inner Vlan Dot1p.
+                         Valid range: 0-7 inclusive";
+            when "../type = SET_INNER_VLAN_PRI";
+            type base-cmn:dot1p;
+        }
+
+        leaf NEW_OUTER_VLAN_ID_VALUE {
+            description "Value for action Set Packet Outer Vlan-Id.
+                         Valid range: 1-4095 inclusive";
+            when "../type = SET_OUTER_VLAN_ID";
+            type base-cmn:vlan-id;
+        }
+
+        leaf NEW_OUTER_VLAN_PRI_VALUE {
+            description "Value for action Mark Dot1p.
+                         Valid range: 0-7 inclusive";
+            when "../type = SET_OUTER_VLAN_PRI";
+            type base-cmn:dot1p;
+        }
+
+        leaf NEW_SRC_MAC_VALUE {
+            description "Value for action Set Packet Src MAC Address";
+            when "../type = SET_SRC_MAC";
+            type yang:mac-address;
+        }
+
+
+        leaf NEW_DST_MAC_VALUE {
+            description "Value for action Set Packet Dst MAC Address";
+            when "../type = SET_DST_MAC";
+            type yang:mac-address;
+        }
+
+        leaf NEW_SRC_IP_VALUE {
+            description "Value for action Set Packet Src IPv4 Address";
+            when "../type = SET_SRC_IP";
+            type inet:ipv4-address;
+        }
+
+        leaf NEW_DST_IP_VALUE {
+            description "Value for action Set Packet Src IPv4 Address";
+            when "../type = SET_DST_IP";
+            type inet:ipv4-address;
+        }
+
+        leaf NEW_SRC_IPV6_VALUE {
+            description "Value for action Set Packet Src IPv6 Address";
+            when "../type = SET_SRC_IPV6";
+            type inet:ipv6-address;
+        }
+
+        leaf NEW_DST_IPV6_VALUE {
+            description "Value for action Set Packet Src IPv6 Address";
+            when "../type = SET_DST_IPV6";
+            type inet:ipv6-address;
+        }
+
+        leaf NEW_DSCP_VALUE {
+            description "Value for action Set Packet DSCP.
+                         Valid range: 0-63 inclusive";
+            when "../type = SET_DSCP";
+            type inet:dscp;
+        }
+
+        leaf NEW_L4_SRC_PORT_VALUE {
+            description "Value for action Set Packet L4 Src Port";
+            when "../type = SET_L4_SRC_PORT";
+            type inet:port-number;
+        }
+
+        leaf NEW_L4_DST_PORT_VALUE {
+            description "Value for action Set Packet L4 Src Port";
+            when "../type = SET_L4_DST_PORT";
+            type inet:port-number;
+        }
+
+        container CPU_QUEUE_VALUE {
+            when "../type = SET_CPU_QUEUE";
+            leaf index {
+                type base-cmn:base-obj-id-type;
+                mandatory "true";
+                description "Refers to the Queue Id of the CPU Queue
+                             defined in QoS data model.
+                             Yang Ref: dell-base-qos/queue/id.";
+            }
+
+            leaf data {
+                type base-cmn:qos-queue-opaque-data;
+                mandatory "true";
+                description
+                    "Opaque blob containing hardware specific Qos queue data.
+                    Yang Ref: dell-base-qos/queue/data.
+                    To get the opaque data, the Application needs to do a
+                    GET operation on the above QoS QoS attribute
+                    only AFTER a successful Observed state change is
+                    published for the Queue configuration.
+                    The Application has to perform this GET every time
+                    the Meter is configured on a new NPU.
+                    It then needs to pass this blob as an attribute
+                    to the ACL Entry object.
+                    Dependency - The Queue should have been successfully
+                    configured on all the NPUs specified in the ACL
+                    entry";
+            }
+        }
+
+        leaf-list EGRESS_MASK_VALUE {
+            when "../type = EGRESS_MASK";
+            type base-cmn:logical-ifindex;
+            description "List of ports to be blocked";
+            status obsolete;
+        }
+
+        leaf-list REDIRECT_PORT_LIST_VALUE {
+            when "../type = REDIRECT_PORT_LIST";
+            type base-cmn:logical-ifindex;
+            description "List of port to be redirected";
+            status obsolete;
+        }
+
+        leaf REDIRECT_INTF_VALUE {
+            type if:interface-ref;
+            description "Port or LAG trunk to Redirect Packet on";
+            when "../type = REDIRECT_INTF";
+        }
+
+        leaf-list EGRESS_INTF_MASK_VALUE {
+            when "../type = EGRESS_INTF_MASK";
+            type if:interface-ref;
+            description "List of ports to be blocked";
+        }
+
+        leaf-list REDIRECT_INTF_LIST_VALUE {
+            when "../type = REDIRECT_INTF_LIST";
+            type if:interface-ref;
+            description "List of port to be redirected";
+        }
+
+        leaf SET_USER_TRAP_ID_VALUE {
+            when "../type = SET_USER_TRAP_ID";
+            type uint32;
+            description "User defined trap id value";
+        }
+
+        leaf SET_PACKET_COLOR_VALUE {
+            when "../type = SET_PACKET_COLOR";
+            type packet-color;
+            description "Packet color value";
+        }
+    }
+
+    list table {
+        description
+            "An Acl-Table is an ordered list of Acl-Entries.
+             A packet is evaluated against each Acl-Entry in the Acl-Table
+             sequentially in order of descending Entry priority to look
+             for a match.
+             The evaluation within a table stops as soon as the first matching
+             ACL entry is identified - the subsequent Acl-entries in the same
+             Acl-Table are ignored for the packet.
+
+             There can be multiple ACL Tables - the evaluation is then repeated
+             for each ACL table.  The ACL actions from all ACL tables are
+             aggregated and then applied to the packet.
+             Conflicting actions are resolved by using Table priority";
+
+        key "id";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this ACL Table belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf id {
+            type base-cmn:base-obj-id-type;
+            description "Unique Id generated upon Create request.
+                         Subsequent Modify or Delete requests required
+                         the Table ID to be passed in.";
+        }
+
+        leaf priority {
+            type uint32;
+            mandatory "true";
+            description
+                "Table priority - determines the Relative priority given to
+                 actions from an acl-entry matched in this table compared to
+                 conflicting actions from acl entries matched in other tables
+                 for the same packet.
+                 Numerically larger number indicates higher table priority.
+                 Actions from tables with higher priority override conflicting
+                 actions from lower priority tables.";
+        }
+
+        leaf size {
+            type uint32;
+            description
+                "The maximum number entries allowed to be created in this
+                 table.";
+        }
+
+        leaf stage {
+            mandatory "true";
+            type base-acl:stage;
+        }
+
+        leaf-list allowed-match-fields {
+            min-elements "1";
+            type match-type;
+            description "restrict the allowed fields that can be used to
+                match packets by acl-entries belonging to this table";
+        }
+
+        leaf-list allowed-actions {
+            type action-type;
+            description "list of allowed actions that could be performed on
+                matched packets by acl-entries belonging to this table.
+                This attribute is optional and is only required by specific
+                platforms. If it's not specified, by default all actions are
+                allowed";
+        }
+        leaf-list udf-group-list {
+            type base-cmn:base-obj-id-type;
+            description "List of UDF Group ID associated with this table";
+        }
+
+        leaf-list npu-id-list {
+            type base-cmn:npu-id;
+            description
+                "Optional subset of NPUs on which this ACL Table needs to be
+                 installed.
+                 If this attribute is not specified then the Table is installed
+                 on all NPUs to which the Table belongs.";
+        }
+
+        leaf name {
+            type string {
+                length 32;
+            }
+            description
+                "Optional user provided name for ACL table. User could use name
+                 as identity other than ID to retrieve table information if name
+                 is given when ACL table being created";
+        }
+    }
+
+    list entry {
+        description
+            "Each Acl-Entry contains a rule and a set of actions.
+             The rule is used to selectively apply the actions only
+             on packets matching the rule.
+
+             The rule defines the filters to match packets by specifying
+             a list of packet fields and the expected values for each of them.
+             The action defines the list of actions to be taken once a
+             packet matches all the filters specified in the rule.
+
+             Each Acl-Entry is uniquely identified by the Acl-Table to
+             which it belongs and its entry id within this table.
+
+             An existing ACL entry can be modified to add/remove/update
+             match filters or actions in two ways -
+              - Overwrite mode
+                    By forming CPS Object out of the top-level ACL Entry object
+                    using the Table ID and Entry ID as keys and providing the
+                    complete list of Match filters and/or Actions as embedded
+                    attributes of this object.
+                    The existing ACL entry will be overwritten with the new
+                    ACL entry defined by such an object.
+.
+              -emental mode
+                    By forming CPS Object out of the inner Match filter or Action
+                    sub-object using the Table ID, Entry ID and Match-Type or
+                    Action-Type as keys and providing the values for a
+                    single Match Filter or single Action as direct attributes
+                    in this object.
+                    Only a single Match Filter or Action can be added/modified/
+                    removed in this way. Only the inner level attributes defined
+                    within the Match or Action subobject below can be present in
+                    this incremental CPS Object.";
+
+        key "table-id id";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this ACL Entry belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf table-id {
+            type base-cmn:base-obj-id-type;
+            description "ACL-Table to which this Entry belongs.";
+        }
+
+        leaf id {
+            type base-cmn:base-obj-id-type;
+            description "Unique Entry Id generated upon Create request.
+                         Scope of this ID is within the ACL Table.
+                         Subsequent Modify or Delete requests require
+                         the Entry ID to be passed in.";
+        }
+
+        leaf priority {
+            type uint32;
+            mandatory "true";
+            description
+                "Entry Priority - Determines the order of evaluation of Entries
+                 within an Acl-Table. Entries with numerically larger number
+                 have higher priority and are evaluated first within the table.";
+        }
+
+        leaf-list npu-id-list {
+            type base-cmn:npu-id;
+            description
+                "Optional subset of NPUs on which this ACL entry needs to be
+                 installed.
+                 If this attribute is not specified then the entry is installed
+                 on all NPUs on which the Table to which the Entry belongs is
+                 installed.";
+        }
+
+        list match {
+            description
+                "Match-filters are a list of packet field, value pairs.
+                 A packet is considered to match an Acl-Entry ONLY when
+                 the values specified for all the packet fields
+                 match those in the actual packet.
+
+                 Only those fields that are in the allowed-fields list of the
+                 Acl-Table to which this Acl-Entry belongs can be used here.
+
+                 An existing ACL entry can be incrementally modified to
+                 add, delete or modify a single Match filter by forming a
+                 CPS object out of this inner Match subobject using the
+                 Match Type as additional key element. Such a CPS Object
+                 should NOT contain any attributes defined outside this
+                 sub-object including the top level match attribute.";
+
+            key "type";
+            min-elements "1";
+
+            uses match-parameters;
+        }
+
+        list action {
+            description
+                "List of actions to be performed on packets matching this
+                 Acl-Entry.
+
+                 An existing ACL entry can be incrementally modified to
+                 add, delete or modify a single Action by forming a
+                 CPS object out of this inner Action subobject using the
+                 Action Type as additional key element. Such a CPS Object
+                 should NOT contain any attributes defined outside this
+                 sub-object including the top level action attribute.";
+
+            key "type";
+
+            uses action-parameters;
+        }
+        leaf table-name {
+            type string {
+                length 32;
+            }
+            description
+                "Optional attribute to specify name of ACL Table to which this
+                 Entry belongs";
+        }
+
+        leaf name {
+            type string {
+                length 32;
+            }
+            description
+                "Optional user provided name for ACL entry. User could use name
+                 as identity other than ID to retrieve entry information if name
+                 is given when ACL entry being created";
+        }
+    }
+
+    list counter {
+        description "Create and configure ACL counter parameters.";
+
+        key "table-id id";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this ACL Counter belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf table-id {
+            type base-cmn:base-obj-id-type;
+            description "ACL-Table to which this Counter belongs.";
+        }
+
+        leaf id {
+            type base-cmn:base-obj-id-type;
+            description "Unique Counter Id generated upon Create request.
+                         Scope of this ID is within the ACL Table.
+                         Subsequent Modify or Delete requests require
+                         the Counter ID to be passed in.";
+        }
+
+        leaf-list types {
+            type counter-type;
+            min-elements "1";
+            description "Packet, Byte counter - more than 1 type
+                         can be specified for the same counter.";
+        }
+
+        leaf-list npu-id-list {
+            type base-cmn:npu-id;
+            description
+                "Optional NPU ID list attribute that allows application
+                 to configure the counter only on specific NPU(s).
+
+                 For a CREATE/SET/DELETE operation, if this optional attribute
+                 is not specified then the counter is
+                 installed/modified/deleted on all NPUs.";
+        }
+
+        leaf name {
+            type string {
+                length 32;
+            }
+            description
+                "Optional user provided name for ACL counter. User could use name
+                 as identity other than ID to retrieve counter information if name
+                 is given when ACL counter being created";
+        }
+
+        leaf table-name {
+            type string {
+                length 32;
+            }
+            description
+                "Optional attribute to specify name of ACL Table to which this
+                 Counter belongs";
+        }
+    }
+
+    list stats {
+        description "NPU ACL entry hit stats.
+                     Stats objects cannot be Created or Deleted.
+                     Stats objects are indexed using the ACL counter object ID.";
+
+        key "table-id counter-id";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this ACL Counter belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf table-id {
+            type base-cmn:base-obj-id-type;
+            description "ACL-Table to which this Counter belongs.";
+        }
+
+        leaf counter-id {
+            type base-cmn:base-obj-id-type;
+            description "ACL-Counter whose stats needs to be set/retrieved.";
+        }
+
+        leaf table-name {
+            type string {
+                length 32;
+            }
+            description "Name of ACL-Table to which this Counter belongs.";
+        }
+
+        leaf counter-name {
+            type string {
+                length 32;
+            }
+            description "Name of ACL-Counter whose stats needs to be set/retrieved.";
+        }
+
+        leaf-list npu-id-list {
+            type base-cmn:npu-id;
+            description
+                "Optional NPU ID list attribute that allows application
+                 to set/retrieve the counter value to/from specific NPU(s).
+
+                 For a GET operation, if more than 1 NPU is specified
+                 in the list, then the counter value returned is the
+                 sum of the counters from all the specified NPUs.
+                 If this optional attribute is not specified then the
+                 counter value returned is the sum of the counters on
+                 all NPUs where the ACL entry is installed.
+
+                 Similarly, for a SET operation, the counter value is
+                 reset on all NPUs specified in the list. If this
+                 optional attribute is not specified then the counter
+                 is reset on all NPUs in which the ACL entry is installed";
+        }
+
+        leaf matched-packets {
+            type yang:counter64;
+            description
+                "Number of packets that have matched the ACL entries
+                 associated with this counter on the given NPU.
+                 This is valid only if PACKET counter type is enabled
+                 for this counter.";
+        }
+
+        leaf matched-bytes {
+            type yang:counter64;
+            description
+                "Number of bytes that have matched the ACL entries
+                 associated with this counter on the given NPU.
+                 This is valid only if BYTE counter type is enabled
+                 for this counter.";
+        }
+    }
+
+    typedef range-type {
+        type enumeration {
+            enum L4_SRC_PORT {
+                value 1;
+                description "Checking source port field of TCP/UDP
+                             header.";
+            }
+
+            enum L4_DST_PORT {
+                value 2;
+                description "Checking destination port field of
+                             TCP/UDP header.";
+            }
+
+            enum OUTER_VLAN {
+                value 3;
+                description "Checking outer VLAN ID.";
+            }
+
+            enum INNER_VLAN {
+                value 4;
+                description "Checking inner VLAN ID.";
+            }
+
+            enum PACKET_LENGTH {
+                value 5;
+                description "Checking length in bytes of L3 payload
+                             plus L3 header.";
+            }
+        }
+    }
+
+    list range {
+        key "id";
+
+        description "List defines Range Checker to check if a certain
+                     parameter falls within a range value";
+
+        leaf id {
+            type base-cmn:base-obj-id-type;
+            description "Unique ID generated upon Create request.
+                         Subsequent Modify and Delete request required
+                         this Range ID to be passed in.";
+        }
+
+        leaf type {
+            mandatory true;
+            type range-type;
+            description "Specify parameter type to check.";
+        }
+
+        leaf limit_min {
+            mandatory true;
+            type uint32;
+            description "Minimum limit of range";
+        }
+
+        leaf limit_max {
+            mandatory true;
+            type uint32;
+            description "Maximum limit of range";
+        }
+    }
+}
+

--- a/python-inocybe-openswitch/models/base-common.yang
+++ b/python-inocybe-openswitch/models/base-common.yang
@@ -1,0 +1,441 @@
+module base-common {
+  namespace "http://www.dellemc.com/networking/os10/base-common";
+  prefix base-cmn;
+
+  organization "Dell EMC";
+  contact
+    "http://www.dell.com/support";
+  description
+    "This module contains a collection of common YANG derived types used
+     in other Base Yang modules.";
+
+  revision 2015-09-24 {
+    description
+      "Added Enum values to breakout-mode";
+  }
+  revision 2015-05-27 {
+    description
+      "Phase 2 of clean-up work";
+  }
+  revision 2015-05-21 {
+    description
+      "Phase 1 of clean-up work";
+  }
+  revision 2015-04-03 {
+    description
+      "Added the opaque data types";
+  }
+  revision 2015-03-12 {
+    description
+      "Initial revision";
+  }
+
+  typedef logical-ifindex {
+    type uint32;
+    description
+      "Uniquely identifies any interface system-wide including
+       physical ports, LAG interfaces and Vlan interfaces";
+  }
+
+  typedef npu-id {
+    type uint32;
+    description
+      "Uniquely identifies a Network Processing Unit hardware
+       in the system";
+  }
+
+  typedef npu-port-id {
+    type uint32;
+    description
+      "Identifies a port within a Network Processing Unit";
+  }
+
+  typedef logical-switch-id {
+    type uint32;
+    description
+      "Logical Switch Identifier. Logical switch is a grouping
+       of one or more NPU(s) in the system. Each NPU can belong
+       to only one logical switch";
+  }
+
+  typedef vlan-id {
+    type uint16 {
+      range "1 .. 4094";
+    }
+    description
+      "This type denotes a IEEE 802.1Q VLAN Identifier.";
+    reference "IEEE 802.1Q";
+  }
+
+  typedef af-type {
+    type enumeration {
+      enum "inet" {
+        /* Address family - IPv4 */
+        value 2;
+      }
+      enum "inet6" {
+        /* Address family - IPv6 */
+        value 10;
+      }
+    }
+    description
+      "Address Family";
+  }
+
+  typedef traffic-path {
+    type enumeration {
+      enum "ingress" {
+        value 1;
+        description
+          "Enable sampling on Ingress packets";
+      }
+      enum "egress" {
+        value 2;
+        description
+          "Enable sampling of Egress packets";
+      }
+      enum "ingress-egress" {
+        value 3;
+        description
+          "Enable sampling of Ingress and Egress packets";
+      }
+    }
+    default "ingress-egress";
+  }
+
+  typedef fec-type {
+    type enumeration {
+      enum "auto" {
+        value 1;
+      }
+      enum "off" {
+        value 2;
+      }
+      enum "cl91-rs" {
+        value 3;
+      }
+      enum "cl74-fc" {
+        value 4;
+      }
+      enum "cl108-rs" {
+        value 5;
+      }
+      enum "not-supported" {
+        value 6;
+      }
+    }
+  }
+
+  typedef admin-status-type {
+    type enumeration {
+      enum "up" {
+        value 1;
+      }
+      enum "down" {
+        value 2;
+      }
+      enum "testing" {
+        value 3;
+      }
+    }
+  }
+
+  typedef oper-status-type {
+    type enumeration {
+      enum "up" {
+        value 1;
+        description
+          "Ready to pass packets.";
+      }
+      enum "down" {
+        value 2;
+        description
+          "Entity is down.";
+      }
+      enum "testing" {
+        value 3;
+        description
+          "In some test mode.  No operational packets can
+           be passed.";
+      }
+      enum "unknown" {
+        value 4;
+        description
+          "Status cannot be determined for some reason.";
+      }
+      enum "dormant" {
+        value 5;
+        description
+          "Waiting for some external event.";
+      }
+      enum "not-present" {
+        value 6;
+        description
+          "Some component (typically hardware) is missing.";
+      }
+      enum "lower-layer-down" {
+        value 7;
+        description
+          "Down due to state of lower-layer interface(s).";
+      }
+      enum "fail" {
+        value 8;
+        description
+          "The interface has an internal failure.";
+      }
+    }
+  }
+
+  typedef stat-type {
+    type enumeration {
+      enum "port-stat" {
+        value 1;
+      }
+      enum "flow-stat" {
+        value 2;
+      }
+      enum "prefix-stat" {
+        value 3;
+      }
+      enum "queue-stat" {
+        value 4;
+      }
+      enum "buffer-stat" {
+        value 5;
+      }
+      enum "interface-stat" {
+        value 6;
+      }
+    }
+    description
+      "various statistics type that can be supported with Flex Stat";
+  }
+
+  // @TODO : To be deprecated. Use IETF iana type
+  typedef interface-type {
+    type enumeration {
+      enum "l3-port" {
+        value 1;
+      }
+      enum "l2-port" {
+        value 2;
+      }
+      enum "loopback" {
+        value 3;
+      }
+      enum "null" {
+        value 4;
+      }
+      enum "tunnel" {
+        value 5;
+      }
+      enum "svi" {
+        value 6;
+      }
+      enum "cpu" {
+        value 7;
+      }
+      enum "management" {
+        value 8;
+      }
+      enum "ethernet" {
+        value 9;
+      }
+      enum "vlan" {
+        value 10;
+      }
+      enum "lag" {
+        value 11;
+      }
+      enum "vrf" {
+        value 12;
+      }
+    }
+    description
+      "Enumeration of the various support interface types";
+  }
+
+  typedef encap-type {
+    type enumeration {
+      enum "tagged" {
+        value 1;
+      }
+      enum "untagged" {
+        value 2;
+      }
+      enum "prio-tagged" {
+        value 3;
+      }
+    }
+    description
+      "Encapsulation types: need to add more types";
+  }
+
+  // @TODO : Check if needed.
+  typedef lag-hash-type {
+    type enumeration {
+      enum "src-ip" {
+        value 1;
+      }
+      enum "dest-ip" {
+        value 2;
+      }
+      enum "src-dest-ip" {
+        value 3;
+      }
+      enum "src-port" {
+        value 4;
+      }
+    }
+    description
+      "lag hashing info types: Need to add more hash types";
+  }
+
+  // @TODO : To be deprecated. Use IETF iana type
+  typedef tun-type {
+    type enumeration {
+      enum "ipv4-tunnel" {
+        value 1;
+      }
+      enum "ipv6-tunnel" {
+        value 2;
+      }
+      enum "gre-tunnel" {
+        value 3;
+      }
+      enum "vxlan-tunnel" {
+        value 4;
+      }
+      enum "nvgre-tunnel" {
+        value 5;
+      }
+      enum "erspan-tunnel" {
+        value 6;
+      }
+      enum "mpls-tunnel" {
+        value 7;
+      }
+    }
+    description
+      "Encapsulation types: need to add more types";
+  }
+
+  typedef base-obj-id-type {
+    type uint64;
+    description
+      "Common type for object IDs returned to Applications";
+  }
+
+  typedef qos-meter-opaque-data {
+    type binary;
+    description
+      "Meter info opaque data blob that Application obtains from
+       QoS module and passes to other Base modules.";
+  }
+
+  typedef qos-queue-opaque-data {
+    type binary;
+    description
+      "Queue info opaque data blob that Application obtains from
+       QoS module and passes to other Base modules.";
+  }
+
+  typedef mirror-opaque-data {
+    type binary;
+    description
+      "Mirroring session opaque data blob that Application obtains from
+       Mirroring module and passes to other Base modules.";
+  }
+
+  typedef lag-opaque-data {
+    type binary;
+    description
+      "LAG opaque data blob that Application obtains from
+       LAG module and passes to other Base modules.";
+  }
+
+  typedef ip-nexthop-group-opaque-data {
+    type binary;
+    description
+      "IP Nexthop group info opaque data blob that Application obtains
+       from Routing module and passes to other Base modules.";
+  }
+
+  typedef mirror-id {
+    type uint32;
+    description
+      "Identifier of the NAS mirror-session";
+  }
+
+  typedef dot1p {
+    type uint8 {range "0..7";}
+    description
+      "3-bit of priority field in 802.1Q header";
+  }
+
+  typedef traffic-class {
+    type uint8;
+    description
+      "Traffic class, i.e. internal QoS level";
+  }
+
+  typedef loopback-type {
+    type enumeration {
+      enum "none" {
+        value 1;
+      }
+      enum "phy" {
+        value 2;
+      }
+      enum "mac" {
+        value 3;
+      }
+    }
+    description "Physical port's loopback modes";
+  }
+  typedef duplex-type {
+    type enumeration {
+      enum "full" {
+        value 1;
+      }
+      enum "half" {
+        value 2;
+      }
+      enum "auto" {
+        value 3;
+      }
+    }
+  }
+  typedef breakout-type {
+    /* Breakout NxM implies N logical interfaces derived from M front panel ports */
+    type enumeration {
+      enum DISABLED {
+        value 1;
+      }
+      enum BREAKOUT_4x1 {
+        value 2;
+      }
+      enum BREAKOUT_2x1 {
+        value 3;
+      }
+      enum BREAKOUT_1x1 {
+        value 4;
+      }
+      enum BREAKOUT_8x2 {
+        value 5; /* 8 logical interfaces derived from 2 front panel ports */
+      }
+      enum BREAKOUT_2x2 {
+        value 6; /* 2 logical interfaces derived from 2 front panel ports */
+      }
+      enum BREAKOUT_4x4 {
+        value 7; /* 4 logical interfaces derived from 4 front panel ports */
+      }
+      enum BREAKOUT_2x4 {
+        value 8; /* 2 logical interfaces derived from 4 front panel ports */
+      }
+      enum BREAKOUT_4x2 {
+        value 9; /* 4 logical interfaces derived from 2 front panel ports */
+      }
+    }
+  }
+}

--- a/python-inocybe-openswitch/models/base-if-common.yang
+++ b/python-inocybe-openswitch/models/base-if-common.yang
@@ -1,0 +1,98 @@
+module base-if-common {
+    namespace "http://www.dellemc.com/networking/os10/base/dell-base-if-common";
+
+    prefix "dell-base-if-cmn";
+
+    import ietf-interfaces {
+        prefix "if";
+    }
+    import ietf-yang-types {
+        prefix "yang";
+    }
+    import base-common {
+        prefix "base-cmn";
+    }
+
+    import dell-interface {
+        prefix "dell-if";
+    }
+    organization "Dell EMC";
+    contact "http://www.dell.com/support";
+
+    description "This model augments the standard interface and adds Dell EMC specific
+                    extensions.  This model contains the entry point for the
+                    interface object extensions.";
+
+    revision "2016-01-01" {
+        description "Initial version.";
+    }
+
+
+    augment "/if:interfaces/if:interface" {
+        description "The following attributes are common to all interface types.";
+
+        leaf if-index {
+            type base-cmn:logical-ifindex;
+            description "Can be used as an alternate to the name key field.  The if-index is the linux representation for the interface.";
+        }
+
+    }
+
+    augment "/if:interfaces-state/if:interface" {
+
+    }
+
+    augment "/if:interfaces-state/if:interface/if:statistics" {
+
+        leaf time-stamp{
+            type yang:timestamp;
+            description "Timestamp at which stats are returned";
+        }
+    }
+
+    typedef operation-type {
+        description "Operation type of interface configuration";
+
+        type enumeration {
+            enum CREATE {
+                value 1;
+                description "Operation to create interface";
+            }
+            enum DELETE {
+                value 2;
+                description "Operation to delete interface";
+            }
+            enum UPDATE {
+                value 3;
+                description "Operation to update interface attributes";
+            }
+        }
+    }
+
+    rpc set-interface {
+        description "This method is used to create, delete or set multiple types of interface. For
+                create operation, mac address will be allocated if it is not given within input argument.
+                Currently there is only one input argument which specified operation type, user should
+                use attributes of the model of corresponding interface type as extra input";
+        input {
+            leaf operation {
+                description "Specify opertion type to configure interface";
+                type operation-type;
+            }
+        }
+    }
+
+    rpc get-mac-address {
+        description "This method is used to get assgined mac address for different type of interfaces.
+                User should give required attributes such as interface-name, type as input. The actual
+                attributes needed depends on requested interface type";
+    }
+
+    augment "dell-if:clear-counters/dell-if:input" {
+
+    }
+
+    augment "dell-if:clear-eee-counters/dell-if:input" {
+
+    }
+}

--- a/python-inocybe-openswitch/models/base-if-fc.yang
+++ b/python-inocybe-openswitch/models/base-if-fc.yang
@@ -1,0 +1,133 @@
+module base-if-fc {
+
+    namespace "http://www.dellemc.com/networking/os10/base-if-fc";
+    prefix "base-if-fc";
+
+    import ietf-interfaces { prefix "if"; }
+    import base-common { prefix "base-cmn"; }
+    import ietf-yang-types { prefix "yang"; }
+    import iana-if-type { prefix "ianaift"; }
+
+    organization
+        "Dell EMC";
+
+    contact
+        "http://www.dell.com/support";
+
+    description
+        "This module contains a collection of YANG definitions for creating fcoe
+        map";
+
+    revision 2016-11-21 {
+        description "Initial version";
+    }
+
+    typedef fcmac-mode {
+        type enumeration {
+            enum "FPMA_MODE" {
+                description
+                  "24 bit FC DID will be prefixed with 24 bit address
+                         configured on fcoe-map for generating mac address";
+                value 1;
+            }
+            enum "NULL_MODE" {
+                description "The mac address will be zero";
+                value 2;
+            }
+            enum "USER_MODE" {
+                description "The mac address will be configured by the user";
+                value 3;
+            }
+         }
+    }
+
+	augment "/if:interfaces/if:interface" {
+        when "if:type = 'ianaift:fibreChannel'";
+
+        leaf bb-credit {
+          type uint32;
+          description "The Buffer-to-Buffer Credit allocation";
+        }
+        leaf bb-credit-recovery {
+          type uint32;
+          description "The Buffer-to-Buffer Credit Recovery";
+        }
+
+        leaf src-mac-mode {
+             type fcmac-mode;
+             description "Specifies how source MAC address is to be formed";
+        }
+
+        leaf src-map-prefix {
+            type uint32;
+            description "Fiber channel mapper prefix for source address";
+        }
+
+        leaf ingress-src-mac {
+            type yang:phys-address;
+            description
+             "Source MAC provided by user and depends on the mac_mode configured";
+        }
+
+        leaf dest-mac-mode {
+             type fcmac-mode;
+             description "Specifies how destination MAC address is to be formed";
+
+        }
+
+        leaf dest-map-prefix {
+            type uint32;
+            description "Fiber channel mapper prefix for destination address";
+        }
+
+        leaf ingress-dest-mac {
+            type yang:phys-address;
+            description
+             "Ingress destination MAC for mapper";
+        }
+
+        leaf fcoe-pkt-vlanid {
+            type base-cmn:vlan-id;
+            description
+             "FCoE packet vlan-id";
+        }
+
+        leaf tag-protocol-id {
+            type uint16;
+            description
+             "Tag Protocol id for FCoE packet";
+        }
+
+        leaf priority {
+            type base-cmn:dot1p;
+            description
+             " Default priority for vlan tag";
+        }
+
+        leaf vft-header {
+            type uint32;
+            description
+             "Virtual Fabric Tagging ID or header";
+        }
+
+        leaf mtu {
+            type uint32;
+            description
+             "FC port MTU";
+        }
+
+        leaf flow-control-enable {
+            type boolean;
+            description
+             "Flow control mode";
+        }
+
+    }
+    augment "/if:interfaces-state/if:interface" {
+        leaf bb-credit-receive {
+            type uint32;
+            description " Buffer-to-Buffer Credit Receive";
+        }
+    }
+}
+

--- a/python-inocybe-openswitch/models/base-if-lag.yang
+++ b/python-inocybe-openswitch/models/base-if-lag.yang
@@ -1,0 +1,74 @@
+module base-if-lag {
+    namespace "http://www.dellemc.com/networking/os10/base-if-lag";
+
+    prefix "base-if-lag";
+
+	import ietf-interfaces {
+		prefix "if";
+	}
+	
+    import base-common {
+        prefix "base-cmn";
+    }
+
+    import base-if-phy {
+        prefix "base-if-phy";
+    }
+
+    organization "Dell EMC";
+    contact "http://www.dell.com/support";
+
+    description "This model augments the standard interface and adds Dell EMC specific
+    				lag extensions.";
+
+    revision "2016-01-01" {
+        description "Initial version.";
+    }
+	
+	augment "/if:interfaces-state/if:interface" {
+        leaf num-ports {
+            type uint32;
+            description "number of members in the lag interface";
+        }	
+	}
+	
+	augment "/if:interfaces/if:interface" {
+		description "This extension is focused on LAG attributes.";
+        leaf id {
+            type uint32;
+            description "Lag id from Applications";
+        }
+
+
+        leaf lag-opaque-data {
+            config false;
+            type base-cmn:lag-opaque-data;
+            description
+                "NPU LAG opaque data associated with the NOGS base LAG module";
+        }
+
+        leaf lag-port-state {
+            description "state of member port in lag to hash traffic
+                disable or enable";
+            type enumeration {
+                enum DISABLE;
+                enum ENABLE;
+            }
+        }
+
+        leaf-list block-port-list {
+            type if:interface-ref;
+            description "Port list to block in NPU";
+        }
+
+        leaf-list unblock-port-list {
+            type if:interface-ref;
+            description "Port list to unblock in NPU";
+        }
+
+        leaf learn-mode{
+            type base-if-phy:mac-learn-mode;
+            description "Mode in which mac adresses are learned on this interface";
+        }
+	}
+}

--- a/python-inocybe-openswitch/models/base-if-linux.yang
+++ b/python-inocybe-openswitch/models/base-if-linux.yang
@@ -1,0 +1,51 @@
+
+module base-if-linux {
+    namespace "http://www.dellemc.com/networking/os10/base-if-linux";
+
+    prefix "base-if-linux";
+
+	import ietf-interfaces {
+		prefix "if";
+	}
+	
+    import base-common {
+        prefix "base-cmn";
+    }
+
+    organization "Dell EMC";
+    contact "http://www.dell.com/support";
+
+    description "This model augments the standard interface and adds Dell EMC specific
+    				extensions.  This model contains the entry point for the
+    				interface object extensions.";
+
+    revision "2016-01-22" {
+        description "Initial version.";
+    }
+	
+	augment "/if:interfaces/if:interface" {
+		description "The following attributes are common to all interface types.";
+		
+        leaf if-index {
+            type base-cmn:logical-ifindex;
+            description "Can be used as an alternate to the name key field.  The if-index is the linux representation for the interface.";
+        }
+		leaf if-flags {
+			type uint32;
+			description "Private interface flags.  The contents are reserved.";
+		}
+		leaf if-master {
+			type uint32;
+			description "The if-index of the master for this specific interface";
+		}
+		leaf dell-type {
+			type base-cmn:interface-type;
+			description "The dell interface type.";
+		}
+	}	
+}
+
+
+
+
+

--- a/python-inocybe-openswitch/models/base-if-mgmt.yang
+++ b/python-inocybe-openswitch/models/base-if-mgmt.yang
@@ -1,0 +1,58 @@
+
+module base-if-mgmt {
+    namespace "http://www.dellemc.com/networking/os10/base-if-mgmt";
+
+    prefix "base-if-mgmt";
+
+	import ietf-interfaces {
+		prefix "if";
+	}
+	
+    import base-common {
+        prefix "base-cmn";
+    }
+
+    import base-interface-common {
+        prefix "base-if";
+    }
+
+    organization "Dell EMC";
+    contact "http://www.dell.com/support";
+
+    description "This model augments the standard interface and adds Dell EMC specific
+    				extensions.  This model contains the entry point for the
+    				interface object extensions.";
+
+    revision "2016-01-22" {
+        description "Initial version.";
+    }
+	
+	augment "/if:interfaces/if:interface" {
+        when "if:type = 'base-if:management' ";
+        description " MGMT Interface configuration attributes";
+	}
+    augment "/if:interfaces-state/if:interface" {
+        when "if:type = 'base-if:management' ";
+        description " MGMT Interface state attributes";
+	}
+    augment "/if:interfaces-state/if:interface/if:statistics" {
+        when "if:type = 'base-if:management' ";
+        description "Interface counter attributes";
+    }
+
+    rpc if_name_change {
+        description "Management interface name change request RPC";
+
+        input {
+            leaf name {
+                type string;
+                description "Management interface name.";
+            }
+
+            leaf new_name {
+                type string;
+                description "Management interface new name.";
+            }
+        }
+    }
+}

--- a/python-inocybe-openswitch/models/base-if-phy.yang
+++ b/python-inocybe-openswitch/models/base-if-phy.yang
@@ -1,0 +1,317 @@
+module base-if-phy {
+    namespace "http://www.dellemc.com/networking/os10/base-if-phy";
+
+    prefix "base-if-phy";
+
+	import ietf-interfaces {
+		prefix "if";
+	}
+	
+    import base-common {
+        prefix "base-cmn";
+    }
+
+	import base-interface-common {
+		prefix "base-if";
+	}
+
+    import base-platform-common {
+       prefix "platform";
+    }
+    	
+    organization "Dell EMC";
+    contact "http://www.dell.com/support";
+
+    description "This model augments the standard interface and adds Dell EMC specific
+    				physical port extensions.";
+
+    revision "2016-01-01" {
+        description "Initial version.";
+    }
+
+	typedef breakout-mode {
+		type enumeration {
+			enum DISABLED {
+                          value 1;
+                        }
+		 	enum BREAKOUT_4x1 {
+                          value 2;
+                        }
+		 	enum BREAKOUT_2x1 {
+                          value 3;
+                        }
+		 	enum BREAKOUT_1x1 {
+                          value 4;
+                        }
+		}
+	}
+
+    typedef mac-learn-mode{
+        description "FDB Learning mode of the interface";
+
+        type enumeration{
+
+            enum DROP{
+              value 1;
+                description "Drop packets with unkown source mac address. Do not learn, Do not forward";
+            }
+
+            enum DISABLE{
+              value 2;
+                description "Do not learn new source MAC. Forward Based on destination MAC";
+            }
+
+            enum HW{
+              value 3;
+                description "Hardware Learning. Learn source MAC. Forward based on destination";
+            }
+
+            enum CPU_TRAP{
+              value 4;
+                description "Trap packets with unknown source MAC to CPU. Do not learn. Do not forward";
+            }
+
+            enum CPU_LOG{
+              value 5;
+                description "Trap packets with unknown source MAC to CPU. Do not learn. Forward based on destination MAC";
+            }
+        }
+    }	
+	
+
+	list front-panel-port {
+        key "front-panel-port";
+
+        description "This map contains the front panel ports and the
+           NPU ports associated with with the front panel ports.";
+
+        leaf front-panel-port {
+            type uint32;
+            description "ID of the front panel port (indexed from 1 to max front panel port)";
+        }
+
+        leaf npu-id {
+            type base-cmn:npu-id;
+            description "The npu that owns the port";
+        }
+
+        leaf media-id {
+            type uint32;
+            description "The media ID of the port - use this to check the corresponding PAS object to get
+            	the acutal media details";
+        }
+
+        leaf-list port {
+        	type base-cmn:npu-port-id;
+        	description "This list contains all of the hardware ports that are contained.  Look up the details on the lane in the
+        	npu-port-lane object";
+        }
+
+        leaf control-port {
+        	type base-cmn:npu-port-id;
+        	description "Use this port for significant operations";
+        }
+
+        leaf default-name {
+        	type string;
+        	description "This is the default name of the port.";
+        }
+
+        leaf mac-offset {
+            type uint32;
+            description "Offset from system base MAC Address. MAC address of the port is calculated by adding mac_offset in base MAC address";
+        }	
+
+        leaf phy-mode {
+            type base-if:phy-mode-type;
+            description "Port PHY mode, Ethernet or FC";
+        }
+
+		leaf breakout-mode {
+			config false;
+			type base-cmn:breakout-type;
+            description "Breakout mode of the front panel port";
+		}
+        leaf port-speed {
+            type base-if:speed;
+            description "port speed of the front panel port";
+        }
+		
+        uses base-if:breakout-capabilities;
+	}
+		
+	list hardware-port {
+        key "npu-id hw-port";
+        description "This entity holds the details of which front panel port corresponds to a specific NPU/hardware port.  This
+                    list is not dynamic and therefore will not change for a single instance of a product.";
+
+        leaf npu-id {
+            type uint32;
+            description "NPU id ";
+        }
+        leaf hw-port {
+            type uint32;
+            description "The hardware ports that are owned by the front panel port.";
+        }
+
+        leaf hw-control-port {
+            type uint32;
+            description "The hardware port that is the master.  Normally one hardware port will be designated master and on this port
+                a user will be able to change the breakout configuration.";
+        }
+
+        leaf subport-id {
+            type uint32;
+            description "the physical lane on which this port exists.";
+        }
+
+		leaf front-panel-port {
+			type uint32;
+            description "The hardware ports that are owned by the front panel port.";
+		}
+		
+		leaf fanout-mode {
+			config false;
+			type breakout-mode;
+		}
+	}
+	
+    list physical {
+        key "npu-id port-id";
+
+        uses base-if:physical-port-address;
+
+        leaf hardware-port-id {
+            type base-cmn:npu-port-id;
+            status deprecated;
+            description "This is the physical hardware port";
+        }
+
+        leaf-list hardware-port-list {
+            type base-cmn:npu-port-id;
+            description "This is the physical hardware port list";
+        }
+
+        leaf phy-mode {
+            type base-if:phy-mode-type;
+            description "Port PHY mode, Ethernet or FC";
+        }
+
+        leaf speed {
+            type base-if:speed;
+            description "Current max configured speed of physical port";
+        }
+
+		leaf front-panel-number {
+			type uint32;
+            description "depreciated.";
+		}
+		
+        leaf-list breakout-capabilities {
+			type breakout-mode ;
+            status deprecated;
+		}
+		
+		leaf fanout-mode {
+			config false;
+			type breakout-mode;
+            status deprecated;
+		}
+		
+        leaf phy-media {
+            type platform:media-type;
+            description "Physical media type ";
+        }
+						
+        leaf loopback {
+           type base-cmn:loopback-type;
+        }
+
+        leaf-list supported-speed {
+            type base-if:speed;
+            description "list of supported speeds in the interface";
+        }
+
+    }
+	
+	augment "/if:interfaces/if:interface" {
+		uses base-if:physical-port-address;
+		
+        leaf phy-media {
+            type platform:media-type;
+            description "Physical media type ";
+        }
+
+        leaf loopback {
+           type base-cmn:loopback-type;
+        }
+
+        leaf identification-led {
+            description "Led state to set OFF(0) / ON (1)";
+            type boolean;
+        }
+        	
+        uses base-if:mac-learn-limit;
+
+        leaf learn-mode{
+            type mac-learn-mode;
+            description "Mode in which mac adresses are learned on this interface";
+        }
+
+        leaf tagging-mode {
+        	type enumeration {
+        		enum UNTAGGED {
+                          value 1;
+        			description "port accepts untagged packets only.";
+        		}
+        		enum TAGGED {
+                          value 2;
+        			description "port accepts tagged packets only.";
+        		}
+        		enum HYBRID {
+                          value 3;
+        			description "port accepts both untagged and tagged packets.";
+        		}
+        	}
+        }
+	}		
+	rpc breakout {
+		description "This method allows the change of the breakout mode on a front panel port and
+			at the same time will create logical interfaces based on the provided names";
+	    input {
+	        leaf front-panel-port {
+	            type uint32;
+	            description "The hardware ports that are owned by the front panel port.";
+	        }
+	        	
+	        leaf breakout-mode {
+				type breakout-mode ;
+			}	
+            leaf port-speed {
+                type base-if:speed;
+            }
+	    }
+	}
+
+	rpc set-breakout-mode {
+		description "This RPC just changes the breakout mode on a front panel port object but
+					doesn't effect any of the logical interfaces.  The expectation is that
+					all logical interfaces are deleted before this operation is executed";
+	    input {
+    	    uses base-if:physical-port-address;
+	        	
+	        leaf breakout-mode {
+	        	description "this is the new mode to configure.";
+				type breakout-mode ;
+			}	
+
+			leaf-list  effected-port {
+				type base-cmn:npu-port-id;
+            	description "These are the ports that are effected by this change.
+            	When breaking out, this should be one port and when breaking in, this should
+            	be all of the ports that need to be convered.";			
+			}
+	    }
+	}
+
+}

--- a/python-inocybe-openswitch/models/base-if-vlan.yang
+++ b/python-inocybe-openswitch/models/base-if-vlan.yang
@@ -1,0 +1,35 @@
+module base-if-vlan {
+    namespace "http://www.dellemc.com/networking/os10/base-if-vlan";
+
+    prefix "base-if-vlan";
+
+    import ietf-interfaces {
+        prefix "if";
+    }
+    import ietf-yang-types {
+        prefix "yang";
+    }
+	
+    import base-common {
+        prefix "base-cmn";
+    }
+
+    organization "Dell EMC";
+    contact "http://www.dell.com/support";
+
+    description "This model augments the standard interface and adds Dell EMC specific
+    				vlan extensions.";
+
+    revision "2016-01-01" {
+        description "Initial version.";
+    }
+	
+    augment "/if:interfaces/if:interface" {
+        when "if:type = 'ianaift:l2vlan' or if:type = 'ianaift:l3vlan'";
+
+        leaf id {
+            type base-cmn:vlan-id;
+            description "the vlan id associated with interface";
+        }	
+    }
+}

--- a/python-inocybe-openswitch/models/base-interface-common.yang
+++ b/python-inocybe-openswitch/models/base-interface-common.yang
@@ -1,0 +1,334 @@
+module base-interface-common {
+
+    namespace "http://www.dellemc.com/networking/os10/base-interface-common";
+    prefix "base-if";
+
+    import iana-if-type { prefix "ianaift"; }
+    import base-common { prefix "base-cmn"; }
+
+    organization
+        "Dell EMC";
+
+    contact "http://www.dell.com/support";
+
+    description
+        "This module contains the collection of YANG definitions for
+        managing interfaces";
+
+    revision 2015-01-29 {
+        description
+            "Initial revision.";
+    }
+
+    identity null {
+      base ianaift:iana-interface-type;
+      description "Null interface type";
+    }
+
+    identity management {
+      base ianaift:iana-interface-type;
+      description "Management interface type";
+    }
+
+    identity cpu {
+      base ianaift:iana-interface-type;
+      description "CPU interface type";
+    }
+    typedef speed {
+        description "Enumeration of port speed.";
+        type enumeration {
+            enum 0MBPS {
+                value 0;
+                description "0Mbps data rate.";
+            }
+
+            enum 10MBPS {
+                value 1;
+                description "10Mbps data rate.";
+            }
+
+            enum 100MBPS {
+                value 2;
+                description "100Mbps data rate.";
+            }
+
+            enum 1GIGE {
+                value 3;
+                description "1G data rate.";
+            }
+
+            enum 10GIGE {
+                value 4;
+                description "10G data rate.";
+            }
+
+            enum 25GIGE {
+                value 5;
+                description "25G data rate.";
+            }
+
+            enum 40GIGE {
+                value 6;
+                description "40G data rate.";
+            }
+
+            enum 100GIGE {
+                value 7;
+                description "100G data rate.";
+            }
+
+            enum AUTO {
+                value 8;
+                description "The speed is dependent on the media type.";
+            }
+            enum 20GIGE {
+                value 9;
+                description "20G data rate.";
+            }
+            enum 50GIGE {
+                value 10;
+                description "50G data rate.";
+            }
+            enum 200GIGE {
+                value 11;
+                description "200G data rate.";
+            }
+            enum 400GIGE {
+                value 12;
+                description "400G data rate.";
+            }
+            enum 4GFC {
+                value 13;
+                description "4G FC data rate.";
+            }
+            enum 8GFC {
+                value 14;
+                description "8G FC data rate.";
+            }
+            enum 16GFC {
+                value 15;
+                description "16G FC data rate.";
+            }
+            enum 32GFC {
+                value 16;
+                description "32G FC data rate.";
+            }
+        }
+    }
+
+    typedef mode {
+        description "Enumeration of physical interface mode";
+        type enumeration {
+            enum MODE_NONE {
+                value 1;
+                description "";
+            }
+
+            enum MODE_L2 {
+                value 2;
+                description "The port only supports L2.";
+            }
+
+            enum MODE_L2HYBRID {
+                value 3;
+                description "The port supports L2 hybrid.";
+            }
+
+            enum MODE_L3 {
+                value 4;
+                description "The port only supports L3.";
+            }
+
+            enum MODE_L2DISABLED {
+                value 5;
+                description "This port is not in L2 Mode";
+            }
+        }
+    }
+    typedef lag-mode-type {
+        description "LAG Mode";
+      type enumeration {
+        enum STATIC {
+            value 1;
+            description "";
+        }
+
+        enum DYNAMIC {
+            value 2;
+            description "";
+        }
+        }
+    }
+
+    typedef lacp-mode-type {
+        description "LACP MODE";
+        type enumeration {
+
+        enum ACTIVE {
+            value 1;
+            description "";
+        }
+
+        enum PASSIVE {
+            value 2;
+            description "";
+        }
+      }
+    }
+
+    typedef vlan-type {
+        description "VLAN-type type definition";
+
+        type enumeration {
+            enum DATA {
+                value 1;
+            }
+            enum MANAGEMENT {
+                value 2;
+            }
+        }
+    }
+
+
+    grouping physical-port-address {
+        leaf unit-id {
+           type uint32;
+           description "The unit containing the front panel port";
+        }
+
+		leaf slot-id {
+			type uint32;
+			description "the slot id of the physical port.";
+		}
+
+        uses npu-port;
+    }
+
+    grouping npu-port {
+        description "NAS npu port information.";
+        leaf npu-id {
+            type base-cmn:npu-id;
+            description "This denotes the npu Id containing the physical port";
+        }
+
+        leaf  port-id {
+            type base-cmn:npu-port-id;
+            description "This denotes the port Id in the npu";
+        }
+    }
+
+    grouping common {
+        description "This is the generic port definition.  Can be reused by any generic interface object.";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch ID";
+        }
+		uses npu-port;
+
+    }
+
+    grouping mac-learn-limit {
+
+        description
+            "List of Mac Learn Limit configuration";
+
+        leaf learn-limit {
+            type uint32;
+            description "Maximum number of MACs allowed to be learned on an interace";
+        }
+
+        leaf dynamic {
+            type boolean;
+            default false;
+            description "Whether the entry created is subject to aging.";
+        }
+
+        leaf station-move {
+            type boolean;
+            default false;
+            description "Whether the station move is allowed or not";
+        }
+
+        leaf mac-sticky {
+            type boolean;
+            default false;
+            description
+                "If True then all dynamically learnt addresses will be converted into static MAC address
+                and it will not be learnt/moved on other ports. Any new learnt MAC are also converted
+                into sticky MAC address. Sticky flag takes precedence over dynamic";
+        }
+
+
+        leaf mll-violation-actions {
+            description "Configurable mac learn limit (mll) actions when mac learn limit is violated";
+            type enumeration {
+                enum LOG {
+                    value 1;
+                    description "Send the Mac-learn-limit violation notification to syslog";
+                }
+                enum SHUTDOWN {
+                    value 2;
+                    description "Shutdown the Interface";
+                }
+            }
+        }
+
+        leaf msm-violation {
+        	description "MAC station move (msm) violation actions.";
+            type enumeration {
+                enum LOG {
+                    value 1;
+                    description "Send the Mac-station-move-violation notification to syslog";
+                }
+                enum OFFENDING_SHUTDOWN {
+                    value 2;
+                    description "Shutdown the offending interface";
+                }
+                enum ORIGINAL_SHUTDOWN {
+                    value 3;
+                    description "Shutdown the original interface";
+                }
+                enum BOTH_SHUTDOWN {
+                    value 4;
+                    description "Disable both the interfaces";
+                }
+            }
+        }
+    }
+  typedef phy-mode-type {
+    type enumeration {
+      enum ETHERNET {
+        value 1;
+      }
+      enum FC {
+        value 2;
+      }
+    }
+  }
+  grouping breakout-capabilities {
+        list br-cap {
+        key "phy-mode breakout-mode port-speed";
+        description "List of breakout capabilities with max port speeds.";
+            leaf phy-mode {
+                type phy-mode-type;
+                description " Physical layer mode , FC or Ethernet";
+            }
+            leaf breakout-mode {
+                type base-cmn:breakout-type ;
+                description "Breakout mode capability.";
+            }
+            leaf port-speed {
+                type base-if:speed;
+                description "Supported speed.";
+            }
+            leaf skip-ports {
+                type uint32;
+                description "Skip ports between two active port for the breakout mode";
+            }
+        }
+    }
+
+
+}
+

--- a/python-inocybe-openswitch/models/base-ip.yang
+++ b/python-inocybe-openswitch/models/base-ip.yang
@@ -1,0 +1,103 @@
+
+
+module base-ip {
+    namespace "http://www.dellemc.com/networking/os10/base-ip";
+    prefix "base-ip";
+
+    import base-common {
+        prefix "base-cmn";
+    }
+
+    import ietf-inet-types {
+        prefix "inet";
+    }
+    organization "Dell EMC";
+
+    contact "http://www.dell.com/support";
+
+    description "This model will support the configruation of IP address.
+
+    	";
+
+    revision 2015-08-12 {
+        description "Initial version.";
+    }
+
+
+	grouping common-ip-config-params {
+	    leaf ifindex {
+	     	type base-cmn:logical-ifindex;
+	      	description "The interface index";
+	    }		
+		leaf enabled {
+			type boolean;
+			description "Set to true to enable IPv6 for the interface.
+                IPv6 is enabled by default for L3 interfaces.";
+		}		
+		leaf forwarding {
+			type boolean;
+			description "Set to true to enable IP forwarding.
+                IP forwarding is enabled by default.";
+		}		
+		leaf vrf-id {
+			type uint32;
+			description "A numerical value of the vrf that contains the interface.  Use 0 for the default.";
+		}
+		leaf name {
+			type string;
+			description "The interfaces's name.";
+		}
+		leaf vrf-name {
+			type string;
+			description "The VRF name.";
+		}
+	}
+
+	list ipv4 {
+		key "name";
+		
+		uses common-ip-config-params;
+		
+		list address {			
+			key "ip";
+		    leaf ip {
+		      	type inet:ip-address;
+		      	description "IP address";
+		    }
+		    leaf prefix-length {
+		    	type uint8;
+		    }
+		     			
+		}		
+	}
+	
+	list ipv6 {
+		key "name";
+		
+		uses common-ip-config-params;
+
+		leaf dup-addr-detect-transmits {
+			type uint32;			
+		}
+
+        leaf autoconf {
+            type boolean;
+            description "Set to true to enable IPv6 address auto-configuration
+                using prefix information in Router advertisements.
+                IPv6 autoconfiguration is enabled by default if forwarding is disabled.";
+		}
+		
+		list address {			
+			key "ip";
+		    leaf ip {
+		      	type inet:ip-address;
+		      	description "IP address";
+		    }
+		    leaf prefix-length {
+		    	type uint32;
+		    }
+		     			
+		}		
+	}
+	
+}	

--- a/python-inocybe-openswitch/models/base-platform-common.yang
+++ b/python-inocybe-openswitch/models/base-platform-common.yang
@@ -1,0 +1,3053 @@
+module base-platform-common {
+
+  namespace "http://www.dellemc.com/networking/os10/base-platform-common";
+
+  prefix "platform";
+
+  import ietf-yang-types {
+    prefix yang;
+  }
+
+  import dell-yang-types {
+    prefix common;
+  }
+
+  import base-common {
+    prefix "base-cmn";
+  }
+
+  import base-interface-common {
+    prefix "base-if";
+  }
+
+  organization "Dell EMC";
+
+  contact "http://www.dell.com/support";
+
+  description "Common definitions for platform hardware
+
+  Copyright (c) 2015-2016 by Dell EMC,
+
+  All rights reserved.";
+
+  revision 2015-11-04 {
+    description
+      "Updated based on new guidelines for Yang Model update";
+  }
+
+  revision 2015-05-20 {
+    description
+      "Added temperature control fault-value type";
+  }
+  revision 2015-04-03 {
+    description "Initial revision.";
+  }
+
+
+  // An entity is any FRU within a chassis
+
+  typedef entity-type {
+    description "Entity type";
+    type enumeration {
+      enum PSU {
+        description "PSU (power supply unit)";
+        value "1";
+      }
+      enum FAN_TRAY {
+        value "2";
+        description "Fan tray";
+      }
+      enum CARD {
+        value "3";
+        description "Card (Linecard, RPM)";
+      }
+    }
+  }
+
+  typedef card-type-type {
+    description "Encoded value for type of card";
+    type uint32;
+  }
+
+  typedef fault-type {
+    description "Code describing cause of fault";
+    type enumeration {
+      enum OK {
+        description "No fault";
+        value "1";
+      }
+      enum UNKNOWN {
+        value "2";
+        description "Unknown error";
+      }
+      enum ECOMM {
+        value "3";
+        description "Communication error";
+      }
+      enum ECFG {
+        value "4";
+        description "Configuration error";
+      }
+      enum ECOMPAT {
+        value "5";
+        description "Compatibility error";
+      }
+      enum EHW {
+        value "6";
+        description "Hardware error";
+      }
+      enum EPOWER {
+        description "Power error";
+      }
+    }
+  }
+
+  typedef fault-value {
+    type uint32;
+  }
+
+  typedef input-power-type {
+    description "Input current";
+    type enumeration {
+      enum UNKNOWN {
+        description "Unknown";
+        value "1";
+      }
+      enum AC {
+        value "2";
+        description "Alternating current";
+      }
+      enum DC {
+        value "3";
+        description "Direct current";
+      }
+    }
+  }
+
+  typedef fan-airflow-type {
+    description "Fan airflow type";
+    type enumeration {
+      enum UNKNOWN {
+        description "Unknown";
+        value "1";
+      }
+      enum NORMAL {
+        value "2";
+        description "Normal airflow";
+      }
+      enum REVERSE {
+        value "3";
+        description "Reverse airflow";
+      }
+    }
+  }
+
+  typedef fan-speed-type {
+    description "Fan speed, in RPM";
+    type uint16;
+    units "RPM";
+  }
+
+  typedef temperature-type {
+    description "Temperature, in degrees C";
+    type int16;
+    units "C";
+  }
+
+  typedef power-usage-type {
+    description "Power consumption, in mW";
+    type uint32;
+    units "mW";
+  }
+
+  typedef fault-severity {
+    description
+      "ITU defined severity values.";
+    type enumeration {
+      enum "cleared" {
+        value 1;
+      }
+      enum "indeterminate" {
+        value 2;
+      }
+      enum "critical" {
+        value 3;
+      }
+      enum "major" {
+        value 4;
+      }
+      enum "minor" {
+        value 5;
+      }
+      enum "warning" {
+        value 6;
+      }
+    }
+  }
+
+  typedef power-measurement-type {
+    description "Power measurement type";
+
+    type enumeration {
+      enum OMA {
+        description "Optical Modulation Amplitude";
+        value "1";
+      }
+      enum average {
+        description "Average Power";
+        value "2";
+      }
+    }
+  }
+
+  typedef media-status {
+
+    description "Media monitor status";
+
+    type enumeration {
+      enum normal-status {
+        description "Normal state, not crossed any threshold values";
+        value "1";
+      }
+
+      enum high-alarm {
+        description "High alarm state";
+        value "2";
+      }
+
+      enum low-alarm {
+        description "Low alarm state";
+        value "3";
+      }
+
+      enum high-warning {
+        description "High warning state";
+        value "4";
+      }
+
+      enum low-warning {
+        description "Low warning state";
+        value "5";
+      }
+    }
+  }
+
+  typedef media-support-status {
+     description "Front panel port Media type support status.";
+
+     type enumeration {
+       enum not-supported {
+         description "Media type is not supported in front panel port.";
+         value "1";
+       }
+
+       enum not-supported-disabled {
+         description "Media type is not supported in front panel port and its not enabled.";
+         value "2";
+       }
+     }
+  }
+
+  typedef port-type {
+    description "Port Type";
+    type enumeration {
+      enum PLUGGABLE {
+        description "Pluggable port type";
+        value "1";
+      }
+      enum FIXED {
+        description "Fixed port type";
+        value "2";
+      }
+      enum BACKPLANE {
+        description "Backplane port type";
+        value "3";
+      }
+    }
+  }
+  typedef media-category {
+    description "Media category";
+    type enumeration {
+      enum SFP {
+        description "SFP media category";
+        value "1";
+      }
+      enum SFP-PLUS {
+        value "2";
+        description "SFP+ media category";
+      }
+      enum QSFP {
+        value "3";
+        description "QSFP media category";
+      }
+      enum QSFP-PLUS {
+        value "4";
+        description "QSFP+ media category";
+      }
+      enum QSFP28 {
+        value "5";
+        description "QSFP28 media category";
+      }
+      enum SFP28 {
+        value "6";
+        description "SFP28 media category";
+      }
+      enum CXP {
+        value "7";
+        description "CXP media category";
+      }
+      enum CXP28 {
+        value "8";
+        description "CXP28 media category";
+      }
+      enum QSFP-DD {
+        value "9";
+        description "QSFP-DD media category";
+      }
+      enum DEPOP-QSFP28 {
+        value "10";
+        description "Depopulated QSFP28 media category";
+      }
+      enum FIXED {
+        value "11";
+        description "Fixed media category";
+      }
+    }
+  }
+
+  typedef media-type {
+      description "Media type";
+      type enumeration {
+          enum AR_POPTICS_NOTPRESENT {
+              value 1;
+              description "Pluggable optics not present";
+          }
+          enum AR_POPTICS_UNKNOWN {
+              value 2;
+              description "Pluggable optics unknown";
+          }
+          enum AR_POPTICS_NOTSUPPORTED {
+              value 3;
+              description "Pluggable optics not supported";
+          }
+          enum AR_SFPPLUS_10GBASE_USR {
+              value 4;
+              description "Pluggable optics SFPPLUS_10GBASE_USR";
+          }
+          enum AR_SFPPLUS_10GBASE_SR {
+              value 5;
+              description "Pluggable optics SFPPLUS_10GBASE_SR";
+          }
+          enum AR_SFPPLUS_10GBASE_LR {
+              value 6;
+              description "Pluggable optics SFPPLUS_10GBASE_LR";
+          }
+          enum AR_SFPPLUS_10GBASE_ER {
+              value 7;
+              description "Pluggable optics SFPPLUS_10GBASE_ER";
+          }
+          enum AR_SFPPLUS_10GBASE_ZR {
+              value 8;
+              description "Pluggable optics SFPPLUS_10GBASE_ZR";
+          }
+          enum AR_SFPPLUS_10GBASE_CX4 {
+              value 9;
+              description "Pluggable optics SFPPLUS_10GBASE_CX4";
+          }
+          enum AR_SFPPLUS_10GBASE_LRM {
+              value 10;
+              description "Pluggable optics SFPPLUS_10GBASE_LRM";
+          }
+          enum AR_SFPPLUS_10GBASE_T {
+              value 11;
+              description "Pluggable optics AR_SFPPLUS_10GBASE_T";
+          }
+          enum AR_SFPPLUS_10GBASE_CUHALFM {
+              value 12;
+              description "Pluggable optics SFPPLUS_10GBASE_CUHALFM";
+          }
+          enum AR_SFPPLUS_10GBASE_CU1M {
+              value 13;
+              description "Pluggable optics SFPPLUS_10GBASE_CU1M";
+          }
+          enum AR_SFPPLUS_10GBASE_CU2M {
+              value 14;
+              description "Pluggable optics SFPPLUS_10GBASE_CU2M";
+          }
+          enum AR_SFPPLUS_10GBASE_CU3M {
+              value 15;
+              description "Pluggable optics SFPPLUS_10GBASE_CU3M";
+          }
+          enum AR_SFPPLUS_10GBASE_CU5M {
+              value 16;
+              description "Pluggable optics SFPPLUS_10GBASE_CU5M";
+          }
+          enum AR_SFPPLUS_10GBASE_CU7M {
+              value 17;
+              description "Pluggable optics SFPPLUS_10GBASE_CU7M";
+          }
+          enum AR_SFPPLUS_10GBASE_CU10M {
+              value 18;
+              description "Pluggable optics SFPPLUS_10GBASE_CU10M";
+          }
+          enum AR_SFPPLUS_10GBASE_ACU7M {
+              value 19;
+              description "Pluggable optics SFPPLUS_10GBASE_ACU7M";
+          }
+          enum AR_SFPPLUS_10GBASE_ACU10M {
+              value 20;
+              description "Pluggable optics SFPPLUS_10GBASE_ACU10M";
+          }
+          enum AR_SFPPLUS_10GBASE_ACU15M {
+              value 21;
+              description "Pluggable optics SFPPLUS_10GBASE_ACU15M";
+          }
+          enum AR_SFPPLUS_10GBASE_DWDM {
+              value 22;
+              description "Pluggable optics SFPPLUS_10GBASE_DWDM";
+          }
+          enum AR_SFPPLUS_10GBASE_DWDM_40KM {
+              value 23;
+              description "Pluggable optics SFPPLUS_10GBASE_DWDM_40KM";
+          }
+          enum AR_SFPPLUS_10GBASE_DWDM_80KM {
+              value 24;
+              description "Pluggable optics SFPPLUS_10GBASE_DWDM_80KM";
+          }
+          enum AR_QSFP_40GBASE_SR4 {
+              value 25;
+              description "Pluggable optics QSFP_40GBASE_SR4";
+          }
+          enum AR_QSFP_40GBASE_SR4_EXT {
+              value 26;
+              description "Pluggable optics QSFP_40GBASE_SR4_EXT";
+          }
+          enum AR_QSFP_40GBASE_LR4 {
+              value 27;
+              description "Pluggable optics QSFP_40GBASE_LR4";
+          }
+          enum AR_QSFP_40GBASE_LM4 {
+              value 28;
+              description "Pluggable optics QSFP_40GBASE_LM4";
+          }
+          enum AR_QSFP_40GBASE_PSM4_LR {
+              value 29;
+              description "Pluggable optics QSFP_40GBASE_PSM4_LR";
+          }
+          enum AR_QSFP_40GBASE_PSM4_1490NM {
+              value 30;
+              description "Pluggable optics QSFP_40GBASE_PSM4_1490NM";
+          }
+          enum AR_QSFP_40GBASE_PSM4_1490NM_1M {
+              value 31;
+              description "Pluggable optics QSFP_40GBASE_PSM4_1490NM_1M";
+          }
+          enum AR_QSFP_40GBASE_PSM4_1490NM_3M {
+              value 32;
+              description "Pluggable optics QSFP_40GBASE_PSM4_1490NM_3M";
+          }
+          enum AR_QSFP_40GBASE_PSM4_1490NM_5M {
+              value 33;
+              description "Pluggable optics QSFP_40GBASE_PSM4_1490NM_5M";
+          }
+          enum AR_4x1_1000BASE_T {
+              value 34;
+              description "Pluggable optics 4x1_1000BASE_T";
+          }
+          enum AR_QSFP_40GBASE_CR4_HAL_M {
+              value 35;
+              status deprecated;
+              description "Pluggable optics QSFP_40GBASE_CR4_HAL_M";
+          }
+          enum AR_QSFP_40GBASE_CR4_1M {
+              value 36;
+              description "Pluggable optics QSFP_40GBASE_CR4_1M";
+          }
+          enum AR_QSFP_40GBASE_CR4_2M {
+              value 37;
+              description "Pluggable optics QSFP_40GBASE_CR4_2M";
+          }
+          enum AR_QSFP_40GBASE_CR4_3M {
+              value 38;
+              description "Pluggable optics QSFP_40GBASE_CR4_3M";
+          }
+          enum AR_QSFP_40GBASE_CR4_5M {
+              value 39;
+              description "Pluggable optics QSFP_40GBASE_CR4_5M";
+          }
+          enum AR_QSFP_40GBASE_CR4_7M {
+              value 40;
+              description "Pluggable optics QSFP_40GBASE_CR4_7M";
+          }
+          enum AR_QSFP_40GBASE_CR4_10M {
+              value 41;
+              description "Pluggable optics QSFP_40GBASE_CR4_10M";
+          }
+          enum AR_QSFP_40GBASE_CR4_50M {
+              value 42;
+              description "Pluggable optics QSFP_40GBASE_CR4_50M";
+          }
+          enum AR_QSFP_40GBASE_CR4 {
+              value 43;
+              description "Pluggable optics QSFP_40GBASE_CR4";
+          }
+          enum AR_4x10_10GBASE_CR1_HAL_M {
+              value 44;
+              status deprecated;
+              description "Pluggable optics 4x10_10GBASE_CR1_HAL_M";
+          }
+          enum AR_4x10_10GBASE_CR1_1M {
+              value 45;
+              description "Pluggable optics 4x10_10GBASE_CR1_1M";
+          }
+          enum AR_4x10_10GBASE_CR1_3M {
+              value 46;
+              description "Pluggable optics 4x10_10GBASE_CR1_3M";
+          }
+          enum AR_4x10_10GBASE_CR1_5M {
+              value 47;
+              description "Pluggable optics 4x10_10GBASE_CR1_5M";
+          }
+          enum AR_4x10_10GBASE_CR1_7M {
+              value 48;
+              description "Pluggable optics 4x10_10GBASE_CR1_7M";
+          }
+          enum AR_SFPPLUS_FC_8GBASE_SR {
+              value 49;
+              description "Pluggable optics SFPPLUS_FC_8GBASE_SR";
+          }
+          enum AR_SFPPLUS_FC_8GBASE_IR {
+              value 50;
+              description "Pluggable optics SFPPLUS_FC_8GBASE_IR";
+          }
+          enum AR_SFPPLUS_FC_8GBASE_MR {
+              value 51;
+              description "Pluggable optics SFPPLUS_FC_8GBASE_MR";
+          }
+          enum AR_SFPPLUS_FC_8GBASE_LR {
+              value 52;
+              description "Pluggable optics SFPPLUS_FC_8GBASE_LR";
+          }
+          enum SFP_SX {
+              value 53;
+              description "Pluggable optics SFP_SX";
+          }
+          enum SFP_LX {
+              value 54;
+              description "Pluggable optics SFP_LX";
+          }
+          enum SFP_ZX {
+              value 55;
+              description "Pluggable optics SFP_ZX";
+          }
+          enum SFP_CX {
+              value 56;
+              description "Pluggable optics SFP_CX";
+          }
+          enum SFP_DX {
+              value 57;
+              description "Pluggable optics SFP_DX";
+          }
+          enum SFP_T {
+              value 58;
+              description "Pluggable optics SFP_T";
+          }
+          enum SFP_FX {
+              value 59;
+              description "Pluggable optics SFP_FX";
+          }
+          enum SFP_CWDM {
+              value 60;
+              description "Pluggable optics SFP_CWDM";
+          }
+          enum SFP_IR1 {
+              value 61;
+              description "Pluggable optics SFP_IR1";
+          }
+          enum SFP_LR1 {
+              value 62;
+              description "Pluggable optics SFP_LR1";
+          }
+          enum SFP_LR2 {
+              value 63;
+              description "Pluggable optics SFP_LR2";
+          }
+          enum SFP_BX10 {
+              value 64;
+              description "Pluggable optics SFP_BX10";
+          }
+          enum SFP_PX {
+              value 65;
+              description "Pluggable optics SFP_PX";
+          }
+          enum 4x_10GBASE_SR_AOCXXM {
+              value 66;
+              description "Pluggable optics 4x10GBASE-SR-AOCXXM";
+          }
+          enum QSFP_40GBASE_SM4 {
+              value 67;
+              description "Pluggable optics QSFP_40GBASE_SM4";
+          }
+          enum QSFP_40GBASE_ER4 {
+              value 68;
+              description "Pluggable optics QSFP_40GBASE_ER4";
+          }
+          enum QSFP_4x10_10GBASE_CR1_2M {
+              value 69;
+              description "Pluggable optics QSFP_4x10_10GBASE_CR1_2M";
+          }
+          enum SFPPLUS_10GBASE_ZR_TUNABLE {
+              value 70;
+              description "Pluggable optics SFPPLUS_10GBASE_ZR_TUNABLE";
+          }
+          enum AR_QSFP28_100GBASE_SR4 {
+              value 71;
+              description "Pluggable optics AR_QSFP28_100GBASE_SR4";
+          }
+          enum AR_QSFP28_100GBASE_LR4 {
+              value 72;
+              description "Pluggable optics AR_QSFP28_100GBASE_LR4";
+          }
+          enum AR_QSFP28_100GBASE_CWDM4 {
+              value 73;
+              description "Pluggable optics AR_QSFP28_100GBASE_CWDM4";
+          }
+          enum AR_QSFP28_100GBASE_PSM4_IR {
+              value 74;
+              description "Pluggable optics AR_QSFP28_100GBASE_PSM4_IR";
+          }
+          enum AR_QSFP28_100GBASE_CR4 {
+              value 75;
+              description "Pluggable optics AR_QSFP28_100GBASE_CR4";
+          }
+          enum AR_QSFP28_100GBASE_AOC {
+              value 76;
+              description "Pluggable optics AR_QSFP28_100GBASE_AOC";
+          }
+          enum AR_QSFP28_100GBASE_CR4_HAL_M {
+              value 77;
+              status deprecated;
+              description "Pluggable optics AR_QSFP28_100GBASE_CR4_HALFM";
+          }
+          enum AR_QSFP28_100GBASE_CR4_1M {
+              value 78;
+              description "Pluggable optics AR_QSFP28_100GBASE_CR4_1M";
+          }
+          enum AR_QSFP28_100GBASE_CR4_2M {
+              value 79;
+              description "Pluggable optics AR_QSFP28_100GBASE_CR4_2M";
+          }
+          enum AR_QSFP28_100GBASE_CR4_3M {
+              value 80;
+              description "Pluggable optics AR_QSFP28_100GBASE_CR4_3M";
+          }
+          enum AR_QSFP28_100GBASE_CR4_4M {
+              value 81;
+              description "Pluggable optics AR_QSFP28_100GBASE_CR4_4M";
+          }
+          enum AR_QSFP28_100GBASE_CR4_5M {
+              value 82;
+              description "Pluggable optics AR_QSFP28_100GBASE_CR4_5M";
+          }
+          enum QSFP28_100GBASE_CR4_7M {
+              value 83;
+              description "Pluggable optics QSFP28_100GBASE_CR4_7M";
+          }
+          enum QSFP28_100GBASE_CR4_10M {
+              value 84;
+              description "Pluggable optics QSFP28_100GBASE_CR4_10M";
+          }
+          enum QSFP28_100GBASE_CR4_50M {
+              value 85;
+              description "Pluggable optics QSFP28_100GBASE_CR4_50M";
+          }
+          enum 4X25_25GBASE_CR1_HALF_M {
+              value 86;
+              status deprecated;
+              description "Pluggable optics 4X25_25GBASE_CR1_HALF_M";
+          }
+          enum 4X25_25GBASE_CR1_1M {
+              value 87;
+              description "Pluggable optics 4X25_25GBASE_CR1_1M";
+          }
+          enum 4X25_25GBASE_CR1_2M {
+              value 88;
+              description "Pluggable optics 4X25_25GBASE_CR1_2M";
+          }
+          enum 4X25_25GBASE_CR1_3M {
+              value 89;
+              description "Pluggable optics 4X25_25GBASE_CR1_3M";
+          }
+          enum 4X25_25GBASE_CR1_4M {
+              value 90;
+              description "Pluggable optics 4X25_25GBASE_CR1_4M";
+          }
+          enum 4X25_25GBASE_CR1 {
+              value 91;
+              description "Pluggable optics 4X25_25GBASE_CR1";
+          }
+          enum 2X50_50GBASE_CR2_HALF_M {
+              value 92;
+              status deprecated;
+              description "Pluggable optics 2X50_50GBASE_CR2_HALF_M";
+          }
+          enum 2X50_50GBASE_CR2_1M {
+              value 93;
+              description "Pluggable optics 2X50_50GBASE_CR2_1M";
+          }
+          enum 2X50_50GBASE_CR2_2M {
+              value 94;
+              description "Pluggable optics 2X50_50GBASE_CR2_2M";
+          }
+          enum 2X50_50GBASE_CR2_3M {
+              value 95;
+              description "Pluggable optics 2X50_50GBASE_CR2_3M";
+          }
+          enum 2X50_50GBASE_CR2_4M {
+              value 96;
+              description "Pluggable optics 2X50_50GBASE_CR2_4M";
+          }
+          enum 2X50_50GBASE_CR2 {
+              value 97;
+              description "Pluggable optics 2X50_50GBASE_CR2";
+          }
+          enum SFP28_25GBASE_CR1 {
+              value 98;
+              description "Pluggable optics SFP28_25GBASE_CR1";
+          }
+          enum SFP28_25GBASE_CR1_HALF_M {
+              value 99;
+              status deprecated;
+              description "Pluggable optics SFP28_25GBASE_CR1_HALF_M";
+          }
+          enum SFP28_25GBASE_CR1_1M {
+              value 100;
+              description "Pluggable optics SFP28_25GBASE_CR1_1M";
+          }
+          enum SFP28_25GBASE_CR1_2M {
+              value 101;
+              description "Pluggable optics SFP28_25GBASE_CR1_2M";
+          }
+          enum SFP28_25GBASE_CR1_3M {
+              value 102;
+              description "Pluggable optics SFP28_25GBASE_CR1_3M";
+          }
+          enum QSFPPLUS_50GBASE_CR2 {
+              value 103;
+              description "Pluggable optics QSFPPLUS_50GBASE_CR2";
+          }
+          enum QSFPPLUS_50GBASE_CR2_1M {
+              value 104;
+              description "Pluggable optics QSFPPLUS_50GBASE_CR2_1M";
+          }
+          enum QSFPPLUS_50GBASE_CR2_2M {
+              value 105;
+              description "Pluggable optics QSFPPLUS_50GBASE_CR2_2M";
+          }
+          enum QSFPPLUS_50GBASE_CR2_3M {
+              value 106;
+              description "Pluggable optics QSFPPLUS_50GBASE_CR2_3M";
+          }
+          enum QSFP_40GBASE_BIDI {
+              value 107;
+              description "Pluggable optics QSFP_40GBASE_BIDI";
+          }
+          enum QSFP_40GBASE_AOC {
+              value 108;
+              description "Pluggable optics QSFP_40GBASE_AOC";
+          }
+          enum QSFP28_100GBASE_LR4_LITE {
+              value 109;
+              description "Pluggable optics QSFP28_100GBASE_LR4_LITE";
+          }
+          enum QSFP28_100GBASE_ER4 {
+              value 110;
+              description "Pluggable optics QSFP28_100GBASE_ER4";
+          }
+          enum QSFP28_100GBASE_ACC {
+              value 111;
+              description "Pluggable optics QSFP28_100GBASE_ACC ";
+          }
+          enum SFP28_25GBASE_SR {
+              value 112;
+              description "Pluggable optics SFP28_25GBASE_SR";
+          }
+          enum SFPPLUS_10GBASE_SR_AOCXXM {
+              value 113;
+              description "Pluggable optics SFPPLUS_10GBASE_SR_AOCXXM";
+          }
+          enum SFP_BX10_UP {
+              value 114;
+              description "Pluggable optics SFP_BX10_UP";
+          }
+          enum SFP_BX10_DOWN {
+              value 115;
+              description "Pluggable optics SFP_BX10_DOWN";
+          }
+          enum SFP_BX40_UP {
+              value 116;
+              description "Pluggable optics SFP_BX40_UP";
+          }
+          enum SFP_BX40_DOWN {
+              value 117;
+              description "Pluggable optics SFP_BX40_DOWN";
+          }
+          enum SFP_BX80_UP {
+              value 118;
+              description "Pluggable optics SFP_BX80_UP";
+          }
+          enum SFP_BX80_DOWN {
+              value 119;
+              description "Pluggable optics SFP_BX80_DOWN";
+          }
+          enum QSFP28_100GBASE_PSM4_PIGTAIL {
+              value 120;
+              description "Pluggable optics QSFP28_100GBASE_PSM4_PIGTAIL";
+          }
+          enum QSFP28_100GBASE_SWDM4 {
+              value 121;
+              description "Pluggable optics QSFP28_100GBASE_SWDM4";
+          }
+          enum QSFP_40GBASE_PSM4_PIGTAIL {
+              value 122;
+              description "Pluggable optics QSFP_40GBASE_PSM4_PIGTAIL";
+          }
+          enum AR_QSFP_40GBASE_CR4_HALFM {
+              value 123;
+              description "Pluggable optics QSFP_40GBASE_CR4_HALFM";
+          }
+          enum AR_4x10_10GBASE_CR1_HALFM {
+              value 124;
+              description "Pluggable optics 4x10_10GBASE_CR1_HALFM";
+          }
+          enum AR_QSFP28_100GBASE_CR4_HALFM {
+              value 125;
+              description "Pluggable optics AR_QSFP28_100GBASE_CR4_HALFM";
+          }
+          enum 4X25_25GBASE_CR1_HALFM {
+              value 126;
+              description "Pluggable optics 4X25_25GBASE_CR1_HALFM";
+          }
+          enum 2X50_50GBASE_CR2_HALFM {
+              value 127;
+              description "Pluggable optics 2X50_50GBASE_CR2_HALFM";
+          }
+          enum SFP28_25GBASE_CR1_HALFM {
+              value 128;
+              description "Pluggable optics SFP28_25GBASE_CR1_HALFM";
+          }
+          enum SFPPLUS_8GBASE_FC_SW {
+              value 129;
+              description "Pluggable optics SFPPLUS_8GBASE_FC_SW";
+          }
+          enum SFPPLUS_8GBASE_FC_LW {
+              value 130;
+              description "Pluggable optics SFPPLUS_8GBASE_FC_LW";
+          }
+          enum SFPPLUS_16GBASE_FC_SW {
+              value 131;
+              description "Pluggable optics SFPPLUS_16GBASE_FC_SW";
+          }
+          enum SFPPLUS_16GBASE_FC_LW {
+              value 132;
+              description "Pluggable optics SFPPLUS_16GBASE_FC_LW";
+          }
+          enum QSFPPLUS_64GBASE_FC_SW4 {
+              value 133;
+              description "Pluggable optics QSFPPLUS_64GBASE_FC_SW4";
+          }
+          enum QSFPPLUS_4X16_16GBASE_FC_SW {
+              value 134;
+              description "Pluggable optics QSFPPLUS_4X16_16GBASE_FC_SW";
+          }
+          enum QSFPPLUS_64GBASE_FC_LW4 {
+              value 135;
+              description "Pluggable optics QSFPPLUS_64GBASE_FC_LW4";
+          }
+          enum QSFPPLUS_4X16_16GBASE_FC_LW {
+              value 136;
+              description "Pluggable optics QSFPPLUS_4X16_16GBASE_FC_LW";
+          }
+          enum QSFP28_128GBASE_FC_SW4 {
+              value 137;
+              description "Pluggable optics QSFP28_128GBASE_FC_SW4";
+          }
+          enum QSFP28_4X32_32GBASE_FC_SW {
+              value 138;
+              description "Pluggable optics QSFP28_4X32_32GBASE_FC_SW";
+          }
+          enum QSFP28_128GBASE_FC_LW4 {
+              value 139;
+              description "Pluggable optics QSFP28_128GBASE_FC_LW4";
+          }
+          enum QSFP28_4X32_32GBASE_FC_LW {
+              value 140;
+              description "Pluggable optics QSFP28_4X32_32GBASE_FC_LW";
+          }
+          enum SFP28_32GBASE_FC_SW {
+              value 141;
+              description "Pluggable optics SFP28_32GBASE_FC_SW";
+          }
+          enum SFP28_32GBASE_FC_LW {
+              value 142;
+              description "Pluggable optics SFP28_32GBASE_FC_LW";
+          }
+          enum SFP28_25GBASE_SR_NOF {
+              value 143;
+              description "Pluggable optics SFP28_25GBASE_SR_NOF";
+          }
+          enum SFP28_25GBASE_eSR {
+              value 144;
+              description "Pluggable optics SFP28_25GBASE_eSR";
+          }
+          enum SFP28_25GBASE_LR {
+              value 145;
+              description "Pluggable optics SFP28_25GBASE_LR";
+          }
+          enum SFP28_25GBASE_LR_LITE {
+              value 146;
+              description "Pluggable optics SFP28_25GBASE_LR_LITE";
+          }
+          enum SFP28_25GBASE_SR_AOCXXM {
+              value 147;
+              description "Pluggable optics SFP28_25GBASE_SR_AOCXXM";
+          }
+          enum SFP28_25GBASE_CR1_LPBK {
+              value 148;
+              description "Pluggable optics SFP28_25GBASE_CR1_LPBK";
+          }
+          enum QSFP28-DD_200GBASE_CR4_HALFM {
+              value 149;
+              description "Pluggable optics QSFP28-DD_200GBASE_CR4_HALFM";
+          }
+          enum QSFP28-DD_200GBASE_CR4_1M {
+              value 150;
+              description "Pluggable optics QSFP28-DD_200GBASE_CR4_1M";
+          }
+          enum QSFP28-DD_200GBASE_CR4_2M {
+              value 151;
+              description "Pluggable optics QSFP28-DD_200GBASE_CR4_2M";
+          }
+          enum QSFP28-DD_200GBASE_CR4_3M {
+              value 152;
+              description "Pluggable optics QSFP28-DD_200GBASE_CR4_3M";
+          }
+          enum QSFP28-DD_200GBASE_CR4_5M {
+              value 153;
+              description "Pluggable optics QSFP28-DD_200GBASE_CR4_5M";
+          }
+          enum QSFP28-DD_200GBASE_CR4 {
+              value 154;
+              description "Pluggable optics QSFP28-DD_200GBASE_CR4";
+          }
+          enum "QSFP28-DD_200GBASE_CR4_1_HALFM" {
+              value 155;
+              description "Pluggable optics QSFP28-DD_200GBASE_CR4_1_HALFM";
+          }
+          enum QSFP28-DD_200GBASE_CR4_2_HALFM {
+              value 156;
+              description "Pluggable optics QSFP28-DD_200GBASE_CR4_2_HALFM";
+          }
+          enum QSFP28-DD_2x100GBASE_CR4_1M {
+              value 157;
+              description "Pluggable optics QSFP28-DD_2x100GBASE_CR4_1M";
+          }
+          enum QSFP28-DD_2x100GBASE_CR4_2M {
+              value 158;
+              description "Pluggable optics QSFP28-DD_2x100GBASE_CR4_2M";
+          }
+          enum QSFP28-DD_2x100GBASE_CR4_3M {
+              value 159;
+              description "Pluggable optics QSFP28-DD_2x100GBASE_CR4_3M";
+          }
+          enum QSFP28-DD_8x25GBASE_CR4_1M {
+              value 160;
+              description "Pluggable optics QSFP28-DD_8x25GBASE_CR4_1M";
+          }
+          enum QSFP28-DD_8x25GBASE_CR4_2M {
+              value 161;
+              description "Pluggable optics QSFP28-DD_8x25GBASE_CR4_2M";
+          }
+          enum QSFP28-DD_8x25GBASE_CR4_3M {
+              value 162;
+              description "Pluggable optics QSFP28-DD_8x25GBASE_CR4_3M";
+          }
+          enum QSFP28-DD_200GBASE_CR4_LPBK {
+              value 163;
+              description "Pluggable optics QSFP28-DD_200GBASE_CR4_LPBK";
+          }
+          enum SFPPLUS_10GBASE_CR_1_HALFM {
+              value 164;
+              description "Pluggable optics SFPPLUS_10GBASE_CR_1.5M";
+          }
+          enum SFPPLUS_10GBASE_CR_2_HALFM {
+              value 165;
+              description "Pluggable optics SFPPLUS_10GBASE_CR_2.5M";
+          }
+          enum SFPPLUS_10GBASE_CR_1M {
+              value 166;
+              description "Pluggable optics SFPPLUS_10GBASE_CR_1M";
+          }
+          enum SFPPLUS_10GBASE_CR_2M {
+              value 167;
+              description "Pluggable optics SFPPLUS_10GBASE_CR_2M";
+          }
+          enum SFPPLUS_10GBASE_CR_3M {
+              value 168;
+              description "Pluggable optics SFPPLUS_10GBASE_CR_3M";
+          }
+          enum SFPPLUS_10GBASE_CR_4M {
+              value 169;
+              description "Pluggable optics SFPPLUS_10GBASE_CR_4M";
+          }
+          enum SFPPLUS_10GBASE_CR_5M {
+              value 170;
+              description "Pluggable optics SFPPLUS_10GBASE_CR_5M";
+          }
+          enum QSFP28-DD_200GBASE_SR4_HALFM {
+              value 171;
+              description "Pluggable optics QSFP28-DD_200GBASE_SR4_HALFM";
+          }
+          enum QSFP28-DD_200GBASE_SR4_1M {
+              value 172;
+              description "Pluggable optics QSFP28-DD_200GBASE_SR4_1M";
+          }
+          enum QSFP28-DD_200GBASE_SR4_2M {
+              value 173;
+              description "Pluggable optics QSFP28-DD_200GBASE_SR4_2M";
+          }
+          enum QSFP28-DD_200GBASE_SR4_3M {
+              value 174;
+              description "Pluggable optics QSFP28-DD_200GBASE_SR4_3M";
+          }
+          enum QSFP28-DD_200GBASE_SR4_5M {
+              value 175;
+              description "Pluggable optics QSFP28-DD_200GBASE_SR4_5M";
+          }
+          enum QSFP28-DD_200GBASE_SR4 {
+              value 176;
+              description "Pluggable optics QSFP28-DD_200GBASE_SR4";
+          }
+          enum QSFP28-DD_200GBASE_SR4_1_HALFM {
+              value 177;
+              description "Pluggable optics QSFP28-DD_200GBASE_SR4_1_HALFM";
+          }
+          enum QSFP28-DD_200GBASE_SR4_2_HALFM {
+              value 178;
+              description "Pluggable optics QSFP28-DD_200GBASE_SR4_2_HALFM";
+          }
+          enum 1GBASE_COPPER {
+              value 179;
+              description "Fixed copper port 1GBASE_COPPER";
+          }
+          enum 10GBASE_COPPER {
+              value 180;
+              description "Fixed copper port 10GBASE_COPPER";
+          }
+          enum 25GBASE_BACKPLANE {
+              value 181;
+              description "Fixed backplane port 25GBASE_BACKPLANE";
+          }
+
+          enum SFPPLUS_10GBASE_SR_AOC1M {
+              value 182;
+              description "Pluggable optics SFPPLUS_10GBASE_SR_AOC1M";
+          }
+
+          enum SFPPLUS_10GBASE_SR_AOC3M {
+              value 183;
+              description "Pluggable optics SFPPLUS_10GBASE_SR_AOC3M";
+          }
+
+          enum SFPPLUS_10GBASE_SR_AOC5M {
+              value 184;
+              description "Pluggable optics SFPPLUS_10GBASE_SR_AOC5M";
+          }
+
+          enum SFPPLUS_10GBASE_SR_AOC10M {
+              value 185;
+              description "Pluggable optics SFPPLUS_10GBASE_SR_AOC10M";
+          }
+
+          enum QSFPPLUS_4X10_10GBASE_SR_AOC10M {
+              value 186;
+              description "Pluggable optics QSFPPLUS_4X10_10GBASE_SR_AOC10M";
+          }
+
+          enum QSFPPLUS_40GBASE_SR_AOC3M {
+              value 187;
+              description "Pluggable optics QSFPPLUS_40GBASE_SR_AOC3M";
+          }
+
+          enum QSFPPLUS_40GBASE_SR_AOC5M {
+              value 188;
+              description "Pluggable optics QSFPPLUS_40GBASE_SR_AOC5M";
+          }
+
+          enum QSFPPLUS_40GBASE_SR_AOC7M {
+              value 189;
+              description "Pluggable optics QSFPPLUS_40GBASE_SR_AOC7M";
+          }
+
+          enum QSFPPLUS_40GBASE_SR_AOC10M {
+              value 190;
+              description "Pluggable optics QSFPPLUS_40GBASE_SR_AOC10M";
+          }
+      }
+  }
+
+  typedef reboot-type {
+    description "define reboot type";
+    type enumeration {
+      enum WARM {
+        description "Warm reboot";
+        value "1";
+      }
+      enum COLD {
+        description "Cold reboot";
+        value "2";
+      }
+    }
+  }
+
+  typedef unit-down-reason {
+    description
+      "Indicates reason for unit down.";
+    type enumeration {
+      enum "version-mismatch" {
+        value 1;
+      }
+      enum "type-mismatch" {
+        value 2;
+      }
+      enum "admin-down" {
+        value 3;
+      }
+      enum "unlicensed" {
+        value 4;
+      }
+      enum "user-triggered" {
+        value 5;
+      }
+      enum "software-triggered" {
+        value 6;
+      }
+      enum "unit-crashed" {
+        value 7;
+      }
+      enum "unknown" {
+        value 8;
+      }
+    }
+  }
+
+  // PAS notify grouping
+
+  grouping pas_notify {
+
+    description "Attributes of pas notify";
+
+    leaf status {
+      description "PAS status";
+      type boolean;
+      config false;
+    }
+  }
+
+  // EEPROM grouping - Everything there is to know about a
+  //                   chassis' or entity's EEPROM
+
+  grouping eeprom {
+    description "Attributes of a chassis' or entity's EEPROM";
+
+    leaf vendor-name {
+      description "Entity vendor name";
+      type string;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity is present
+      // Persistent: N/A
+      // Notification: no
+    }
+
+    leaf product-name {
+      description "Entity product name";
+      type string;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity is present
+      // Persistent: N/A
+      // Notification: no
+    }
+
+    leaf hw-version {
+      description "Entity hardware version";
+      type string;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity is present
+      // Persistent: N/A
+      // Notification: no
+    }
+
+    leaf platform-name {
+      description "Entity platform name";
+      type string;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity is present
+      // Persistent: N/A
+      // Notification: no
+    }
+
+    leaf ppid {
+      description "Entity PPID";
+      type string;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity is present
+      // Persistent: N/A
+      // Notification: no
+    }
+
+    leaf part-number {
+      description "Entity Part Number";
+      type string;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity is present
+      // Persistent: N/A
+      // Notification: no
+    }
+
+    leaf service-tag {
+      description "Entity service tag";
+      type string;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity is present
+      // Persistent: N/A
+      // Notification: no
+    }
+
+    leaf service-code {
+      description "Entity service code";
+      type string;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity is present
+      // Persistent: N/A
+      // Notification: no
+    }
+  }
+
+
+  // Chassis grouping - Everything there is to know about a chassis
+  //
+  // Contains all attributes of a chassis, regardless of chassis type
+  // (pizza box, controlling bridge or port extender) and stacking
+  // (or not) configuration.
+
+  grouping chassis {
+    description "Attributes of a chassis";
+
+    uses eeprom;  //ude EEPROM attributes
+
+    leaf oper-status {
+      description "Operational status";
+      type base-cmn:oper-status-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: None
+      // Persistent: N/A
+      // Notification: Yes; parameters (oper_status)
+      // Notes: This attribute is normally "up".  Essentially, it reflects
+      //        the result (status) of the last CPS get or set request for
+      //        the object.  It will be set to "fail"
+      //        if there was any failure in getting or setting any
+      //        attribute for the last object get or set request.  Errors
+      //        experienced when getting attributes are reflected in values
+      //        returned for those attributes, e.g. an error in obtaining
+      //        the power usage is reflected as returning -1 for the
+      //        power-usage attribute.  If there were no errors for the
+      //        last CPS request, this attribute will be set to "up".
+    }
+
+    leaf fault-type {
+      description "Cause of fault";
+      type fault-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if oper-status == fail
+      // Persistent: N/A
+      // Notification: Yes; parameters (fault_type)
+    }
+
+    leaf num_mac_addresses {
+      description "Number of MAC addresses assigned to chassis";
+      type uint32;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: None
+      // Persistent: N/A
+      // Notification: no
+    }
+
+    leaf base_mac_addresses {
+      description "Base MAC addresses assigned to chassis";
+      type yang:mac-address;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: None
+      // Persistent: N/A
+      // Notification: no
+    }
+
+    leaf power-usage {
+      description "Total power consumed by chassis";
+      type power-usage-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: May not be supported for all platforms.
+      //               Value shall be 0 for unsupported platforms.
+      // Persistent: N/A
+      // Notification: No
+      // Notes: A negative value indicates an error.
+    }
+
+    leaf power-off {
+      description "Kill power to chassis";
+      type boolean;
+      config true;
+      // Qualifiers: target
+      // Dependencies: May not be supported for all platforms.
+      //               On unsupported platforms, setting this attribute has
+      //               no effect.
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf active-rpm-slot {
+      description "Slot of active RPM";
+      type uint8;
+      config true;
+      // Qualifiers: observed, realtime, target
+      // Dependencies: May not be supported for all platforms.
+      //               For those that do not support RPM redundancy, value is
+      //               fixed to slot of single RPM, or single card for
+      //               pizza-box or port extender chassis, and setting this
+      //               attribute has no effect.
+      // Default: N/A
+      // Persistent: N/A
+      // Notification: Yes; parameters (slot)
+      // Notes: Writing a value different from the current observed/
+      //        realtime value to the target qualifiers initiates an
+      //        RPM switchover.
+    }
+
+    leaf reboot {
+      description "reboot type";
+      type reboot-type;
+      config true;
+      // Qualifiers: observed, realtime, target
+      // Dependencies: Valid only if card is present
+      // Persistent: N/A
+      // Notification: no
+    }
+  }
+
+
+  // Entity grouping - Everything there is to know about an entity (FRU)
+  //
+  // Contains all attributes of an entity within a chassis, which is a field-
+  // replacable unit (FRU) part of a chassis (actual or virtual).  For
+  // consistency, things that can be an FRU on any platform at treated as
+  // FRUs, even if it is not an FRU for a given platform.  Thus, a card is
+  // treated as an entity (FRU), even for a platform that does not have
+  // cards -- a pizza-box chassis or port extender will have a single
+  // (virtual) card entity, one that is always present.
+
+  grouping entity {
+    description "Attributes of an entity (FRU)";
+
+    uses eeprom;        //ude EEPROM attributes
+
+    leaf name {
+      description "Printable name of entity";
+      type string;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: None
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf present {
+      description "Entity present flag";
+      type boolean;  // true <=> Entity present in slot
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: None
+      // Persistent: N/A
+      // Notification: Yes; parameters (present)
+    }
+
+    leaf insertion-cnt {
+      description "Number of times entity inserted";
+      type yang:gauge64;
+      config true;
+      // Qualifiers: observed, realtime, target
+      // Dependencies: None
+      // Persistent: Across process restart: yes
+      //             Across kernel restart:  yes
+      //             Across power cycle:     yes
+      // Notification: No
+      // Notes: Writing any value for this attribute to the target space
+      //        has the effect of resetting this counter to 0.
+    }
+
+    leaf insertion-timestamp {
+      description "Timestamp of last entity insertion";
+      type yang:timestamp;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: None
+      // Persistent: Across process restart: yes
+      //             Across kernel restart:  yes
+      //             Across power cycle:     yes
+      // Notification: No
+    }
+
+    leaf admin-status {
+      description "Administrative status";
+      type base-cmn:admin-status-type;
+      config true;
+      // Qualifiers: observed, realtime, target
+      // Dependencies: None
+      // Default: up
+      // Persistent: Across process restart: Yes
+      //             Across kernel restart:  No
+      //             Across power cycle:     No
+      // Notification: Yes; parameters (admin_status)
+      // Notes: Up <=> Polling of entity enabled, CPS/FUSE requests
+      //               satisfied
+      //        Down <=> Polling of entity disabled, CPS/FUSE requests
+      //                 rejected
+      //        Testing <=> As with down, but also includes others in
+      //                    same diag class
+    }
+
+    leaf oper-status {
+      description "Operational status";
+      type base-cmn:oper-status-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: !present => oper-status == unknown
+      //               admin-status == testing => oper-status == down
+      // Persistent: N/A
+      // Notification: Yes; parameters (oper_status)
+    }
+
+    leaf fault-type {
+      description "Cause of fault";
+      type fault-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if oper-status == fail
+      // Persistent: N/A
+      // Notification: Yes; parameters (fault_type)
+    }
+
+    // The following attributes apply only to entities of type card
+
+    choice entity-type-choice {
+      case card {
+        leaf power-on {
+          description "Power control for entity";
+          type boolean;  // true <=> Power to entity enabled
+          config true;
+          // Qualifiers: observed, realtime, target
+          // Dependencies: Only applicable to card entities
+          // Default: false
+          // Persistent: Across process restart: yes
+          //             Across kernel restart:  yes
+          //             Across power cycle:     no
+          // Notification: No
+        }
+
+        leaf reboot {
+          description "reboot type";
+          type reboot-type;
+          config true;
+          // Qualifiers: observed, realtime, target
+          // Dependencies: Valid only if card is present
+          // Persistent: N/A
+          // Notification: no
+        }
+      }
+    }
+  }
+
+
+  // PSU grouping - Everything there is to know about a PSU
+  //
+  // This grouping serves as an extension of the entity grouping
+  // for PSUs.
+
+  grouping psu {
+    description "Attributes of a power supply";
+
+    leaf input-type {
+      description "Input current type";
+      type input-power-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity is present
+      // Persistent: N/A
+      // Notification: no
+    }
+
+    leaf fan-airflow-type {
+      description "Direction of airflow for PSU fan(s)";
+      type fan-airflow-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity is present
+      // Persistent: N/A
+      // Notification: no
+    }
+  }
+
+
+  // Fan tray grouping - Everything there is to know about a fan tray
+  //
+  // This grouping serves as an extension to the entity grouping for
+  // fan trays.
+
+  grouping fan-tray {
+    description "Attributes of a fan tray";
+
+    leaf fan-airflow-type {
+      description "Direction of airflow for fans";
+      type fan-airflow-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity is present
+      // Persistent: N/A
+      // Notification: no
+    }
+  }
+
+
+  // Card grouping - Everything there is to know about a card
+  //
+  // This grouping serves as an extenstion of the entity grouping for
+  // cards.  Note that for platforms that do not have actual field-replacable
+  // cards, such as a pizza-box or port-extender chassis, there still be card
+  // entities -- exactly 1 (virtual) card, in 1 (virtual) slot, which can
+  // never be removed (i.e. will always show as present).
+
+  grouping card {
+    description "Attributes of a card";
+
+    leaf card-type {
+      description "Type of card";
+      type card-type-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity is present
+      // Persistent: N/A
+      // Notification: no
+    }
+  }
+
+
+  // Fan grouping - Everything there is to know about a fan
+
+  grouping fan {
+    description "Attributes of a (PSU or fan tray) fan";
+
+    leaf oper-status {
+      description "Operational status";
+      type base-cmn:oper-status-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity present.
+      //               admin-status(entity) == testing => oper-status == down.
+      // Persistent: N/A
+      // Notification: Yes; parameters (oper_status)
+    }
+
+    leaf fault-type {
+      description "Cause of fault";
+      type fault-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity present and
+      //               if oper-status == fail
+      // Persistent: N/A
+      // Notification: Yes; parameters (fault_type)
+    }
+
+    leaf speed {
+      description "Fan speed, in RPM";
+      type fan-speed-type;
+      config true;
+      // Qualifiers: observed, realtime, target
+      // Dependencies: Valid only if entity present
+      // Default: Maximum speed for fan (see below)
+      // Persistent: N/A
+      // Notification: No
+      // Notes: A fault is indicated (see above) if a fan's current speed
+      //        is not what the target speed specified
+    }
+
+    leaf speed_pct {
+      description "Fan speed, as % of maximum";
+      type uint8;
+      config true;
+      // Qualifiers: observed, realtime, target
+      // Dependencies: Valid only if entity present
+      // Default: Maximum speed for fan (see below)
+      // Persistent: N/A
+      // Notification: No
+      // Notes: A fault is indicated (see above) if a fan's current speed
+      //        is not what the target speed specified
+    }
+
+    leaf max_speed {
+      description "Maximum speed of fan, in RPM";
+      type fan-speed-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity present
+      // Persistent: N/A
+      // Notification: No
+    }
+  }
+
+
+  // LED grouping - Everything there is to know about an LED
+
+  grouping led {
+    description "Attributes of an LED";
+
+    leaf oper-status {
+      description "Operational status";
+      type base-cmn:oper-status-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity present.
+      //               admin-status == testing => oper-status == down.
+      // Persistent: N/A
+      // Notification: Yes; parameters (oper_status)
+    }
+
+    leaf fault-type {
+      description "Cause of fault";
+      type fault-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity present and
+      //               if oper-status == fail
+      // Persistent: N/A
+      // Notification: Yes; parameters (fault_type)
+    }
+
+    leaf req_on {
+      description "Illumination state of LED requested by application";
+      type boolean;  // true <=> LED on
+      config true;
+      // Qualifiers: observed, realtime, target
+      // Dependencies: Valid only if entity present.
+      //               Either 'on' or 'message' attribute supported,
+      //               depending on platform.
+      // Default: false
+      // Persistent: Across process restarts: Yes
+      //             Across kernel restarts:  No
+      //             Across power cycles:     No
+      // Notification: No
+    }
+
+    leaf on {
+      description "Illumination state of physical LED";
+      type boolean;  // true <=> LED on
+      config true;
+      // Qualifiers: observed, realtime, target
+      // Dependencies: Valid only if entity present.
+      //               Either 'on' or 'message' attribute supported,
+      //               depending on platform.
+      // Default: false
+      // Persistent: Across process restarts: Yes
+      //             Across kernel restarts:  No
+      //             Across power cycles:     No
+      // Notification: No
+    }
+  }
+
+
+  // Display grouping - Everything there is to know about a text message
+  //                    display
+
+  grouping display {
+    description "Attributes of a text message display";
+
+    leaf oper-status {
+      description "Operational status";
+      type base-cmn:oper-status-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity present.
+      //               admin-status == testing => oper-status == down.
+      // Persistent: N/A
+      // Notification: Yes; parameters (oper_status)
+    }
+
+    leaf on {
+      description "Power state of physical Digit Display LED";
+      type boolean;  // true <=> Digit Display LED on
+      config true;
+      // Qualifiers: observed, realtime, target
+      // Dependencies: Valid only if entity present.
+      //               Either 'on' or 'message' attribute supported,
+      //               depending on platform.
+      // Default: false
+      // Persistent: Across process restarts: Yes
+      //             Across kernel restarts:  No
+      //             Across power cycles:     No
+      // Notification: No
+    }
+
+    leaf fault-type {
+      description "Cause of fault";
+      type fault-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity present and
+      //               if oper-status == fail
+      // Persistent: N/A
+      // Notification: Yes; parameters (fault_type)
+    }
+
+    leaf message {
+      description "Message to display in text display";
+      type string;
+      config true;
+      // Qualifiers: observed, realtime, target
+      // Dependencies: Valid only if entity present.
+      //               Either 'on' or 'message' attribute supported,
+      //               depending on platform.
+      // Default: ""
+      // Persistent: Across process restarts: Yes
+      //             Across kernel restarts:  No
+      //             Across power cycles:     No
+      // Notification: No
+    }
+  }
+
+
+  // Temperature sensor grouping - Everything there is to know about a
+  //                               temperature sensor
+
+  grouping temperature {
+    description "Attributes of a temperature sensor";
+
+    leaf oper-status {
+      description "Operational status";
+      type base-cmn:oper-status-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity present.
+      //               admin-status == testing => oper-status == down.
+      // Persistent: N/A
+      // Notification: Yes; parameters (oper_status)
+    }
+
+    leaf fault-type {
+      description "Cause of fault";
+      type fault-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity present and
+      //               if oper-status == fail
+      // Persistent: N/A
+      // Notification: Yes; parameters (fault_type)
+    }
+
+    leaf temperature {
+      description "Current temperature";
+      type temperature-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity present
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf shutdown_threshold {
+      description "Threshold for hardware-based shutdown";
+      type temperature-type;
+      config true;
+      // Qualifiers: observed, realtime, target
+      // Dependencies: Valid only if entity present
+      // Default: Not set
+      // Persistent: No
+      // Notification: No
+    }
+
+    leaf thresh-enable {
+      description "Enable threshold detection";
+      type boolean;
+      config true;
+      // Qualifiers: observed, realtime, target
+      // Dependencies: Valid only if entity present
+      // Default: False
+      // Persistent: No
+      // Notification: No
+    }
+
+    leaf last-thresh {
+      description "Last threshold temperature crossed";
+      type temperature-type;
+      config false;
+      // Qualifiers: observed, realtime, target
+      // Dependencies: Valid only if entity present and threshold crossed
+      // Default: Not set
+      // Persistent: No
+      // Notification: Yes
+    }
+  }
+
+
+  // Temperature sensor range threshold grouping - Everything there is
+  //                                               to know about
+  //                                               temperature ranges
+
+  grouping temp_threshold {
+    description "Attributes of a temperature sensor threshold";
+
+    leaf hi {
+      description "Threshold for increasing temperature";
+      type temperature-type;
+      config true;
+      // Qualifiers: observed, realtime, target
+      // Dependencies: Valid only if entity present
+      // Default: Not set
+      // Persistent: No
+      // Notification: No
+    }
+
+    leaf lo {
+      description "Threshold for decreasing temperature";
+      type temperature-type;
+      config true;
+      // Qualifiers: observed, realtime, target
+      // Dependencies: Valid only if entity present
+      // Default: Not set
+      // Persistent: No
+      // Notification: No
+    }
+  }
+
+
+  // PLD grouping - Everything there is to know about programmable logic
+  //                devices (PLDs)
+
+  grouping pld {
+    description "Attributes of a programmable logic device (PLD)";
+
+    leaf version {
+      description "PLD firmware version";
+      type string;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if entity present
+      // Persistent: N/A
+      // Notification: No
+    }
+  }
+
+
+  // Port module grouping - Everything there is no know about linecard
+  //                        port modules
+
+  grouping port-module {
+    description "Attributes of a linecard port module";
+
+    leaf present {
+      description "Module present flag";
+      type boolean;  // true <=> Module present in module slot
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: None
+      // Persistent: N/A
+      // Notification: Yes; parameters (present)
+    }
+
+    leaf insertion-cnt {
+      description "Number of times module inserted";
+      type yang:gauge64;
+      config true;
+      // Qualifiers: observed, realtime, target
+      // Dependencies: None
+      // Persistent: Across process restart: yes
+      //             Across kernel restart:  yes
+      //             Across power cycle:     yes
+      // Notification: No
+      // Notes: Writing any value for this attribute to the target space
+      //        has the effect of resetting this counter to 0.
+    }
+
+    leaf insertion-timestamp {
+      description "Timestamp of last module insertion";
+      type yang:timestamp;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: None
+      // Persistent: Across process restart: yes
+      //             Across kernel restart:  yes
+      //             Across power cycle:     yes
+      // Notification: No
+    }
+
+    leaf admin-status {
+      description "Administrative status";
+      type base-cmn:admin-status-type;
+      config true;
+      // Qualifiers: observed, realtime, target
+      // Dependencies: None
+      // Default: up
+      // Persistent: Across process restart: Yes
+      //             Across kernel restart:  No
+      //             Across power cycle:     No
+      // Notification: Yes; parameters (admin_status)
+      // Notes: Up <=> Polling of module enabled, CPS/FUSE requests
+      //               satisfied
+      //        Down <=> Polling of module disabled, CPS/FUSE requests
+      //                 rejected
+      //        Testing <=> As with down, but also includes others in
+      //                    same diag class
+    }
+
+    leaf oper-status {
+      description "Operational status";
+      type base-cmn:oper-status-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: !present => oper-status == unknown.
+      //               admin-status == testing => oper-status == down.
+      // Persistent: N/A
+      // Notification: Yes; parameters (oper_status)
+    }
+
+    leaf fault-type {
+      description "Cause of fault";
+      type fault-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if oper-status == fail
+      // Persistent: N/A
+      // Notification: Yes; parameters (fault_type)
+    }
+
+    // TBD
+  }
+
+  /* PAS Media releated configuration grouping */
+
+  grouping pas-media-config {
+    description "Attributes of PAS media configuration.";
+
+    leaf lock-down-status {
+      description "Lock down feature status.";
+
+      type boolean;
+      config true;
+    }
+
+    leaf led-control {
+      description "LED control flag";
+
+      type boolean;
+      config false;
+    }
+    leaf identification-led-control {
+      description "Identification LED control flag, PAS owns front panel port identification 
+                   led control if this attribute value is True";
+      type boolean;
+      config false;
+    }
+  }
+
+
+  // Optical media adapter grouping - Everything there is to know about
+  //                                  optical media adapters
+
+  grouping media {
+    description "Attributes of an optical media adapter";
+
+    leaf present {
+      description "Adapter present flag";
+      type boolean;  // true <=> Module present in port slot
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: None
+      // Persistent: N/A
+      // Notification: Yes; parameters (present)
+    }
+
+    leaf port-type {
+      description "Media type is pluggable or fixed or backplane or ...";
+      type port-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: None
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf-list sub-port-id {
+      description "The effective id for that port. Normally a single number except in cases where a port has >1 density; for example QSFP28-DD. List length is port density";
+      type uint32;
+      config false;
+      // Dependencies: Number of items in list is the port density for that port
+    }
+
+    leaf port-density {
+      description "Used to account for ports that have multiple logical ports; example QSFP28-DD. This is also the number of sub-port-ids";
+      type uint32;
+      config false;
+      // Notes: Default is 1 since most ports map to 1 logical port
+    }
+
+    leaf insertion-cnt {
+      description "Number of times adapter inserted";
+      type yang:gauge64;
+      config true;
+      // Qualifiers: observed, realtime, target
+      // Dependencies: None
+      // Persistent: Across process restart: yes
+      //             Across kernel restart:  yes
+      //             Across power cycle:     yes
+      // Notification: No
+      // Notes: Writing any value for this attribute to the target space
+      //        has the effect of resetting this counter to 0.
+    }
+
+    leaf insertion-timestamp {
+      description "Timestamp of last adapter insertion";
+      type yang:timestamp;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: None
+      // Persistent: Across process restart: yes
+      //             Across kernel restart:  yes
+      //             Across power cycle:     yes
+      // Notification: No
+    }
+
+    leaf admin-status {
+      description "Administrative status";
+      type base-cmn:admin-status-type;
+      config true;
+      // Qualifiers: observed, realtime, target
+      // Dependencies: None
+      // Default: up
+      // Persistent: Across process restart: Yes
+      //             Across kernel restart:  No
+      //             Across power cycle:     No
+      // Notification: Yes; parameters (admin_status)
+      // Notes: Up <=> Polling of module enabled, CPS/FUSE requests
+      //               satisfied
+      //        Down <=> Polling of module disabled, CPS/FUSE requests
+      //                 rejected
+      //        Testing <=> As with down, but also includes others in
+      //                    same diag class
+    }
+
+    leaf oper-status {
+      description "Operational status";
+      type base-cmn:oper-status-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: !present => oper-status == unknown.
+      //               admin-status == testing => oper-status == down.
+      // Persistent: N/A
+      // Notification: Yes; parameters (oper_status)
+    }
+    leaf support-status {
+      description "Media support status.";
+      type media-support-status;
+      config false;
+    }
+
+    leaf category {
+      description "Media category";
+      type media-category;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf type {
+      description "Media type";
+      type media-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf capability {
+      description "Media speed capability";
+      type base-if:speed;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf vendor-id {
+      description "Vendor id of the physical media";
+      type binary {
+        length "3";
+      }
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf serial-number {
+      description "Serial number of the physical media";
+      type string {
+        length "17";
+      }
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf qualified {
+      description "Is vendor qualified or not";
+      type boolean; // true <=> If it is vendor qualified media
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf high-power-mode {
+      description "Enable high power mode";
+      type boolean; // true <=> If its enable
+      config true;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf identifier {
+      description "Type of serial transceiver";
+      type uint32;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf ext-identifier {
+      description "Extended identifier of type of serial transceiver";
+      type uint32;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf connector {
+      description "Code for connector type";
+      type uint32;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf transceiver {
+      description "Code for electronic or optical compatibility";
+      type binary {
+        length "8";
+      }
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+    leaf encoding {
+      description "Code for serial encoding algorithm";
+      type uint32;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+    leaf br-nominal  {
+      description "Nominal signaling rate, units of 100Mbits/sec ";
+      type uint32;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Units: 100 MBps
+      // Persistent: N/A
+      // Notification: No
+    }
+    leaf rate-identifier  {
+      description "Type of rate select functionality";
+      type uint32;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf length-sfm-km {
+      description "Link length supported for SMF fiber in km";
+      type uint32;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Units: km
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf length-sfm {
+      description "Link length supported for single mode fiber, units of 100m";
+      type uint32;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Units: 100m
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf length-om2 {
+      description "Link length supported for 50um OM2 fiber, units of 10m";
+      type uint32;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Units: 10m
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf length-om1 {
+      description "Link length supported for 62.5um OM1 fiber, units of 10m";
+      type uint32;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Units: 10m
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf length-cable {
+      description "Link length supported for copper or direct attach cable, units of m";
+      type uint32;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Units: m
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf length-om3 {
+      description "Link length supported for 50um OM3 fiber, units of 10m";
+      type uint32;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Units: 10m
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf vendor-name  {
+      description "Vendor name (ASCII)";
+      type string {
+        length "17";
+      }
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf ext-transceiver  {
+      description "Extended Transceiver Codes";
+      type uint32;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf vendor-pn {
+      description "Part number provided by SFP+ transceiver vendor (ASCII)";
+      type string {
+        length "17";
+      }
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf vendor-rev {
+      description "Revision level for part number provided by vendor (ASCII)";
+      type binary {
+        length "2";
+      }
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf wavelength {
+      description "Laser wavelength (Passive/Active Cable Specification Compliance)";
+      type uint32;
+      units "nm";
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    choice media-category {
+      case qsfp-plus {
+        leaf wavelength-tolerance {
+          description "Guaranteed range of laser wavelength";
+          type uint32;
+          config false;
+          // Qualifiers: observed, realtime
+          // Dependencies: Valid only if present = true
+          // Persistent: N/A
+          // Notification: No
+        }
+        leaf max-case-temp {
+          description "Maximum Case Temperature in Degrees C";
+          type uint32;
+          config false;
+          // Qualifiers: observed, realtime
+          // Dependencies: Valid only if present = true
+          // Persistent: N/A
+          // Notification: No
+        }
+      }
+      case sfp-plus {
+        leaf br-max{
+          description "Upper bit rate margin, units of % ";
+          type uint32;
+          config false;
+          // Qualifiers: observed, realtime
+          // Dependencies: Valid only if present = true
+          // Units: Percent
+          // Persistent: N/A
+          // Notification: No
+        }
+
+        leaf br-min {
+          description "Lower bit rate margin, units of %";
+          type uint32;
+          config false;
+          // Qualifiers: observed, realtime
+          // Dependencies: Valid only if present = true
+          // Units: Percent
+          // Persistent: N/A
+          // Notification: No
+        }
+
+        leaf sff-8472-compliance {
+          description "Indicates which revision of SFF-8472 the transceiver complies with";
+          type uint32;
+          config false;
+          // Qualifiers: observed, realtime
+          // Dependencies: Valid only if present = true
+          // Persistent: N/A
+          // Notification: No
+        }
+      }
+    }
+
+    leaf cc_base {
+      description "Check code for Base ID Fields (addresses 0 to 62)";
+      type uint32;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf options {
+      description "Indicates which optional SFP+ signals are implemented";
+      type uint32;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf date-code {
+      description "Vendor's manufacturing date code";
+      type binary {
+        length "8";
+      }
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf diag-mon-type{
+      description "Indicates which type of diagnostic monitoring is implemented (if any)";
+      type uint32;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf enhanced-options {
+      description "Indicates which optional enhanced features are implemented (if any)";
+      type uint32;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf cc_ext {
+      description "Check code for the Extended ID Fields (addr. 64 to 94)";
+      type uint32;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf vendor-Specific {
+      description "Vendor Specific EEPROM";
+      type binary;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf rate-select-state {
+      description "Rate select state";
+      type boolean;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: None
+      // Persistent: N/A
+      // Notification: Yes; parameters (present)
+    }
+
+    leaf rx-power-measurement-type {
+      description "Received power measurement type";
+      type power-measurement-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+
+    // Media Alarm and Warning thresholds
+
+    leaf temp-high-alarm-threshold {
+      description "Temperature High alarm";
+      type common:xfloat;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf temp-low-alarm-threshold {
+      description "Temperature Low alarm";
+      type common:xfloat;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf temp-high-warning-threshold {
+      description "Temperature High warning";
+      type common:xfloat;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf temp-low-warning-threshold {
+      description "Temperature Low warning";
+      type common:xfloat;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf voltage-high-alarm-threshold {
+      description "Voltage High alarm";
+      type common:xfloat;
+      config false;
+      units "mV";
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf voltage-low-alarm-threshold {
+      description "Voltage Low alarm";
+      type common:xfloat;
+      config false;
+      units "mV";
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf voltage-high-warning-threshold {
+      description "Voltage High warning";
+      type common:xfloat;
+      config false;
+      units "mV";
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf voltage-low-warning-threshold {
+      description "Voltage Low warning";
+      type common:xfloat;
+      config false;
+      units "mV";
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf rx-power-high-alarm-threshold {
+      description "RX Power High alarm";
+      type common:xfloat;
+      config false;
+      units "mW";
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf rx-power-low-alarm-threshold {
+      description "RX Power Low alarm";
+      type common:xfloat;
+      config false;
+      units "mW";
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf rx-power-high-warning-threshold {
+      description "RX Power High warning";
+      type common:xfloat;
+      config false;
+      units "mW";
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf rx-power-low-warning-threshold {
+      description "RX Power Low warning";
+      type common:xfloat;
+      config false;
+      units "mW";
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf bias-high-alarm-threshold {
+      description "Bias High alarm";
+      type common:xfloat;
+      config false;
+      units "mA";
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf bias-low-alarm-threshold {
+      description "Bias Low alarm";
+      type common:xfloat;
+      config false;
+      units "mA";
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf bias-high-warning-threshold {
+      description "Bias High warning";
+      type common:xfloat;
+      config false;
+      units "mA";
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf bias-low-warning-threshold {
+      description "Bias Low warning";
+      type common:xfloat;
+      config false;
+      units "mA";
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf tx-power-high-alarm-threshold {
+      description "Tx power High alarm";
+      type common:xfloat;
+      config false;
+      units "mW";
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf tx-power-low-alarm-threshold {
+      description "Tx power Low alarm";
+      type common:xfloat;
+      config false;
+      units "mW";
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf tx-power-high-warning-threshold {
+      description "Tx power High warning";
+      type common:xfloat;
+      config false;
+      units "mW";
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf tx-power-low-warning-threshold {
+      description "Tx power Low warning";
+      type common:xfloat;
+      config false;
+      units "mW";
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+
+    // Media real time monitor data
+
+
+    leaf current-temperature {
+      description "Current temperature";
+      type common:xfloat;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf current-voltage {
+      description "Current voltage";
+      type common:xfloat;
+      config false;
+      units "mV";
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf temp-state {
+      description "Temperature High/Low alarm/warning state";
+      type media-status;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: Yes
+    }
+
+    leaf voltage-state {
+      description "Voltage High/Low alarm/warning state";
+      type media-status;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: Yes
+    }
+
+    // Config parameters
+
+    leaf autoneg {
+      description "Auto Negotiation";
+      type boolean;
+      default true;
+      config true;
+    }
+
+    leaf-list supported-speed {
+      description "Interface supported speed list";
+      type base-if:speed;
+      config true;
+    }
+    leaf target_wavelength {
+      description "Configured wavelength for tunable media";
+      type common:xfloat;
+      config true;
+    }
+  }
+
+
+  // Optical media adapter channel grouping - Everything there is to know
+  //                                          about an optical media
+  //                                          adapter channel
+
+  grouping media-channel {
+    description "Attributes of a channel of an optical media adapter";
+
+    leaf state {
+      description "Channel state (Enable/Disable)";
+      type boolean; //true <=> if channel is enabled
+      config true;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if  media present = true
+      // Persistent: N/A
+      // Units : N/A
+      // Notification: No
+    }
+
+    leaf rx-power {
+      description "RX power";
+      type common:xfloat;
+      config false;
+      units "mW";
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if media present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf tx-power {
+      description "TX power";
+      type common:xfloat;
+      config false;
+      units "mW";
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if media present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf tx-bias-current {
+      description "TX Bias Current";
+      type common:xfloat;
+      config false;
+      units "mA";
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if media present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf oper-status {
+      description "Operational status";
+      type base-cmn:oper-status-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: !present => oper-status == unknown.
+      //               admin-status == testing => oper-status == down.
+      // Persistent: N/A
+      // Notification: Yes; parameters (oper_status)
+    }
+
+    leaf rx-loss {
+      description "Channel TX loss status";
+      type boolean;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: Yes
+    }
+
+    leaf tx-loss {
+      description "Channel TX loss status";
+      type boolean;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: Yes
+    }
+
+    leaf tx-fault {
+      description "Channel TX fault status";
+      type boolean;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: Yes
+    }
+
+    leaf tx-disable {
+      description "Channel TX disable status";
+      type boolean;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: Yes
+    }
+
+    leaf rx-power-state {
+      description "RX power High/Low alarm/warning state";
+      type media-status;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: Yes
+    }
+
+    leaf tx-power-state {
+      description "TX power High/Low alarm/warning state";
+      type media-status;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: Yes
+    }
+
+    leaf tx-bias-state {
+      description "TX-BIAS High/Low alarm/warning state";
+      type media-status;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: Yes
+    }
+
+    leaf cdr-enable {
+      description "CDR enable/disable";
+      type boolean;
+      config true;
+    }
+
+    // Config parameters
+
+    leaf speed {
+      description "Speed to derive and set LED state";
+      type base-if:speed;
+      config true;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if present = true
+      // Persistent: N/A
+      // Notification: No
+    }
+
+    leaf autoneg {
+      description "Auto Negotiation";
+      type boolean;
+      default true;
+      config true;
+    }
+
+    leaf-list supported-speed {
+      description "Interface supported speed list";
+      type base-if:speed;
+      config true;
+    }
+  }
+
+
+  // PHY grouping - Everything there is no know about PHYs
+
+  grouping phy {
+    description "Attributes of a port PHY";
+
+    leaf admin-status {
+      description "Administrative status";
+      type base-cmn:admin-status-type;
+      config true;
+      // Qualifiers: observed, realtime, target
+      // Dependencies: None
+      // Default: up
+      // Persistent: Across process restart: Yes
+      //             Across kernel restart:  No
+      //             Across power cycle:     No
+      // Notification: Yes; parameters (admin_status)
+      // Notes: Up <=> Polling of PHY enabled, CPS/FUSE requests
+      //               satisfied
+      //        Down <=> Polling of PHY disabled, CPS/FUSE requests
+      //                 rejected
+      //        Testing <=> As with down, but also includes others in
+      //                    same diag class
+    }
+
+    leaf oper-status {
+      description "Operational status";
+      type base-cmn:oper-status-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: !present => oper-status == unknown.
+      //               admin-status == testing => oper-status == down.
+      // Persistent: N/A
+      // Notification: Yes; parameters (oper_status)
+    }
+
+    leaf fault-type {
+      description "Cause of fault";
+      type fault-type;
+      config false;
+      // Qualifiers: observed, realtime
+      // Dependencies: Valid only if oper-status == fail
+      // Persistent: N/A
+      // Notification: Yes; parameters (fault_type)
+    }
+
+    // TBD
+  }
+
+  // Contains all the attributes of host system
+  // Attributes contains info about host system
+
+  grouping host-system {
+
+      description "Attributes of host system";
+
+      leaf booted {
+          description "flag for host system booted successfully";
+          type boolean;
+      }
+
+      leaf software-rev {
+          description "Host system software revision";
+          type string {
+              length "32";
+          }
+      }
+
+      leaf slot-number {
+          description "host system slot number";
+          type uint16;
+      }
+
+  }
+
+  // Contains all the attributes of a comm-dev
+  // comm-dev works as communication channel
+  // between host(card) and master
+
+  grouping comm-dev {
+
+      leaf comm-msg {
+          description "msg between host system and master";
+          type string {
+              length "4096";
+          }
+      }
+
+      leaf chassis-service-tag {
+          description "Chassis service tag";
+          type string {
+              length "34";
+          }
+      }
+
+      leaf comm-dev-firmware-rev {
+          description "comm-dev firmware revision";
+          type string {
+              length "64";
+          }
+      }
+
+  }
+
+}

--- a/python-inocybe-openswitch/models/dell-extensions.yang
+++ b/python-inocybe-openswitch/models/dell-extensions.yang
@@ -1,0 +1,52 @@
+module dell-extensions {
+    namespace "http://www.dellemc.com/networking/os10/dell-extensions";
+    prefix os10-ext;
+
+    description
+        "This module contains definitions for Dell EMC proprietary
+         Yang extensions.";
+
+    revision 2015-12-07 {
+        description 
+            "Initial version";
+    } 
+
+    extension edit-version {
+        description
+             "Backend edit callback functions can be conformant to 
+              netconf engine edit2 or edit1 version. This extension 
+              will be used to  determine the backend edit callback version
+              supported by the backend for container, list or choice.
+                   
+              This yang extension is checked just before registering the 
+              callback functions with the netconf engine.";
+        argument ver; 
+    }
+
+    extension val-cb {
+        description
+              "This extension defines the name of callback function to
+               validate configuration.";
+        argument cb_name; 
+    }
+
+    extension pre-hook {
+        description
+              "Pre hooks are used to define user callbacks to the
+               transaction. Pre-hook callbacks are invoked within
+               the trsnaction when an object is modified.";
+        argument cb_name; 
+    }
+
+    extension ifname-trans {
+        description
+              "ifname-trans are used to define the need to translate
+               an interface name";
+    }
+
+    extension delete-empty-container {
+        description
+              "Delete a non-presence container if a container is empty";
+    }
+
+}

--- a/python-inocybe-openswitch/models/dell-interface.yang
+++ b/python-inocybe-openswitch/models/dell-interface.yang
@@ -1,0 +1,855 @@
+module dell-interface {
+  namespace "http://www.dellemc.com/networking/os10/dell-interface";
+  prefix "dell-if";
+
+  import ietf-interfaces { prefix "if"; }
+  import base-common { prefix "base-cmn"; }
+  import base-interface-common { prefix "base-if"; }
+  import ietf-yang-types { prefix yang; }
+  import iana-if-type { prefix "ianaift"; }
+
+  organization "Dell EMC";
+  contact "http://www.dell.com/support";
+
+  description "This model augments the standard interface and adds Dell EMC specific
+    extensions. This model contains the entry point for the interface
+    object extensions.";
+
+  revision "2016-01-01" {
+    description "Initial version.";
+  }
+
+  augment "/if:interfaces" {
+    container vlan-globals {
+      leaf default-vlan-id {
+        type if:interface-ref;
+        must "/if:interfaces/if:interface[if:name = current()]"
+         +   "/dell-if:vlan-type = 'DATA'" {
+          error-message
+            "Cannot configure default VLAN as management VLAN!";
+        }
+        default "vlan1";
+        description
+              "Default vlan id for the switch";
+      }
+    }
+  }
+
+  augment "/if:interfaces/if:interface" {
+    description "The following attributes are common to all interface types.";
+
+    leaf mtu {
+      type uint32;
+      default "1532";
+      description
+        "The MTU of the interface.";
+    }
+    leaf phys-address {
+        type yang:phys-address;
+        description
+          "The interface's address at its protocol sub-layer.";
+    }
+    leaf eee {
+        type uint32;
+        description
+            "EEE (802.3az) state for this interface";
+    }
+    leaf tx-idle-time {
+        type uint16;
+        description
+            "Tx idle time";
+    }
+    leaf tx-wake-time {
+        type uint16;
+        description
+            "Tx wake time";
+    }
+    leaf vrf-name {
+        type string;
+        description "VRF/Namespace name";
+    }
+  }
+
+  // Phy and LAG
+  augment "/if:interfaces/if:interface" {
+    when "if:type = 'ianaift:ethernetCsmacd' or if:type = 'ianaift:ieee8023adLag'";
+
+    leaf mode {
+      type base-if:mode;
+      default "MODE_L2";
+      description "L2, L2_HYBRID or L3";
+    }
+    leaf load-interval {
+        type uint32 {
+          range "30..299";
+        }
+        default "299";
+        description
+          "Traffic sampling interval for the interface";
+    }
+  }
+
+  // Phy specific
+  augment "/if:interfaces/if:interface" {
+        when "if:type = 'ianaift:ethernetCsmacd' or if:type = 'base-if:management'
+             or  if:type = 'ianaift:fibreChannel'";
+
+        leaf duplex {
+          type base-cmn:duplex-type;
+          default "auto";
+          description
+                "The interface duplex";
+        }
+        leaf auto-negotiation {
+          type boolean;
+          description
+                "Link auto-negotiation setting on the interface";
+        }
+        leaf negotiation {
+            type enumeration {
+                enum "auto" {
+                  value 1;
+                }
+                enum "on" {
+                  value 2;
+                }
+                enum "off" {
+                  value 3;
+                }
+            }
+            description
+                "Negotiation setting on the interface";
+        }
+        leaf speed {
+          type base-if:speed;
+          default "AUTO";
+          description
+                "Should be removed and used from ietf yang model";
+        }
+      }
+
+
+
+    augment "/if:interfaces-state/if:interface" {
+        when "if:type = 'ianaift:ethernetCsmacd' or if:type = 'base-if:management'
+             or  if:type = 'ianaift:fibreChannel'";
+
+
+        leaf duplex {
+          type base-cmn:duplex-type;
+          description
+                "The interface duplex";
+        }
+        leaf auto-negotiation {
+          type boolean;
+          default "true";
+          description
+                "Link auto-negotiation setting on the interface";
+        }
+        leaf-list supported-speed {
+            type base-if:speed;
+            description "list of supported speeds in the interface";
+        }
+
+        leaf discontinuity-time-timeticks {
+          type yang:timestamp;
+          description
+                 "The time on the most recent occasion at which any one or
+                  more of this interface's counters suffered a
+                  discontinuity.  If no such discontinuities have occurred
+                  since the last re-initialization of the local management
+                  subsystem, then this node contains the time the local
+                  management subsystem re-initialized itself.";
+        }
+
+    }
+
+  // LAG specfic
+  augment "/if:interfaces/if:interface" {
+        when "if:type = 'ianaift:ieee8023adLag'";
+        description "This extension is focused on LAG attributes.";
+
+        leaf min-links {
+          type uint32 {
+            range "1..32";
+          }
+          description
+                "Minimum number of members in port channel group";
+          default "1";
+        }
+
+        leaf lag-mode {
+          description "Mode of lag to be create static lag or dynamic lag";
+          type base-if:lag-mode-type;
+          default "STATIC";
+        }
+
+        list member-ports {
+          key "name";
+          description
+                "This has member interfaces";
+          leaf name {
+            type if:interface-ref;
+            must "/if:interfaces/if:interface[if:name = current()]"
+             +   "/if:type = 'ianaift:ethernetCsmacd'" {
+              error-message
+                "Only Ethernet interfaces can be added as member ports to a port-channel!";
+            }
+          }
+          leaf lacp-mode {
+            type base-if:lacp-mode-type;
+            must "../../dell-if:lag-mode = 'DYNAMIC'"  {
+            description
+                    "lacp mode";
+            }
+          }
+        }
+      }
+  /* Ethernet specific */
+  augment "/if:interfaces/if:interface" {
+    when "if:type = 'ianaift:ethernetCsmacd'";
+
+    leaf fec {
+      type base-cmn:fec-type;
+      description
+              "Forward Error Correction type auto, disable or FEC type.
+               It is only applicable for 100G, 50G and 25G interfaces and it will throw Error
+               on any other type of interfaces. BASE module sets the default configuration
+               based on the support by plugged-in media and the Hardware";
+    }
+    leaf oui {
+       type uint32 {
+         range "0..16777215";
+       }
+       description
+          " Organisationally Unique Identifier for vendor Identification.
+            It is only applicable for 25G and 50G interfaces. Allowed range is
+            0 to 0xffffff and default value is 25G Consortium OUI 0x6A737D.
+            OUI configuration should be same for all 25G interface in a front panel port";
+    }
+  }
+
+  augment "/if:interfaces-state/if:interface" {
+    when "if:type = 'ianaift:ethernetCsmacd'";
+
+    leaf fec {
+      type base-cmn:fec-type;
+      description
+              "Forward Error Correction type auto, disable or FEC type.
+               It is only applicable for 100G, 50G and 25G interfaces";
+    }
+    leaf oui {
+       type uint32 {
+         range "0..16777215";
+       }
+       description
+          " Organisationally Unique Identifier for vendor Identification.
+            It is only applicable for 25G and 50G interfaces. Allowed range is
+            0 to 0xffffff and default value is 25G Consortium OUI 0x6A737D";
+    }
+  }
+  // VLAN specfic
+  augment "/if:interfaces/if:interface" {
+    when "if:type = 'ianaift:l2vlan' or if:type = 'ianaift:l3vlan'";
+
+    leaf enable-statistics {
+      type boolean;
+      description "Enable/Disable statistics";
+    }
+
+    leaf learning-mode {
+      type boolean;
+            description "Enable/Disable learning per VLAN";
+    }
+
+    leaf vlan-type {
+      description "VLAN type (data/management)";
+      type base-if:vlan-type;
+      default "DATA";
+    }
+
+    leaf-list tagged-ports {
+      type if:interface-ref;
+      must "/if:interfaces/if:interface[if:name = current()]"
+         + "/dell-if:mode = 'MODE_L2HYBRID'"
+         + " or (../dell-if:vlan-type = 'MANAGEMENT'"
+         + " and /if:interfaces/if:interface[if:name = current()]"
+         + "/if:type = 'base-if:management')" {
+        error-message
+          "Interface being added (to vlan) is not in switchport mode trunk!";
+      }
+    }
+
+    leaf-list untagged-ports {
+      type if:interface-ref;
+      must "/if:interfaces/if:interface[if:name = current()]"
+         + "/dell-if:mode = 'MODE_L2' or
+            /if:interfaces/if:interface[if:name = current()]"
+         + "/dell-if:mode = 'MODE_L2HYBRID'"
+         + " or (../dell-if:vlan-type = 'MANAGEMENT'"
+         + " and /if:interfaces/if:interface[if:name = current()]"
+         + "/if:type = 'base-if:management')" {
+        error-message
+          "Interface being added (to vlan) is not in switchport mode access or trunk!";
+      }
+    }
+  }
+
+  augment "/if:interfaces-state/if:interface" {
+   when "if:type = 'ianaift:fibreChannel'";
+
+       leaf bb-credit {
+           type uint32;
+           description "The Buffer-to-Buffer Credit allocation";
+       }
+
+       leaf fc-mtu {
+           type uint32;
+           description
+              "FC port MTU";
+       }
+       leaf npu-speed {
+           type base-if:speed;
+           description "Port's NPU Speed";
+       }
+    }
+
+  augment "/if:interfaces-state/if:interface/if:statistics" {
+     description
+        "Interface counter attributes";
+
+        leaf if-in-vlan-discards {
+            description "Number of interface incoming vlan discarded packets";
+            type yang:counter64;
+        }
+        leaf if-out-qlen {
+            description "Number of interface outgoing queue length";
+            type yang:counter64;
+        }
+        leaf ether-drop-events {
+            description "Number of ethernet drop events";
+            type yang:counter64;
+        }
+        leaf ether-multicast-pkts {
+            description "Number of ethernet multicast packets";
+            type yang:counter64;
+        }
+        leaf ether-broadcast-pkts {
+            description "Number of ethernet broadcast packets";
+            type yang:counter64;
+        }
+        leaf ether-undersize-pkts {
+            description "Number of ethernet undersize packets";
+            type yang:counter64;
+        }
+        leaf ether-fragments {
+            description "Number of ethernet fragments";
+            type yang:counter64;
+        }
+        leaf ether-oversize-pkts {
+            description "Number of ethernet stats oversize packets";
+            type yang:counter64;
+        }
+        leaf ether-rx-oversize-pkts {
+            description "Number of ethernet received oversize packets";
+            type yang:counter64;
+        }
+        leaf ether-tx-oversize-pkts {
+            description "Number of ethernet transmitted oversize packets";
+            type yang:counter64;
+        }
+        leaf ether-jabbers {
+            description "Number of ethernet stats jabbers";
+            type yang:counter64;
+        }
+        leaf ether-octets {
+            description "Number of ethernet stats octets";
+            type yang:counter64;
+        }
+        leaf ether-pkts {
+            description "Number of ethernet stats packets";
+            type yang:counter64;
+        }
+        leaf ether-collisions {
+            description "Number of ethernet stats collisions";
+            type yang:counter64;
+        }
+        leaf ether-crc-align-errors {
+            description "Number of ethernet stats crc align errors";
+            type yang:counter64;
+        }
+        leaf ether-tx-no-errors {
+            description "Number of ethernet stats tx no errors";
+            type yang:counter64;
+        }
+        leaf ether-rx-no-errors {
+            description "Number of ethernet stats rx no errors";
+            type yang:counter64;
+        }
+        leaf green-discard-dropped-packets {
+            description "Number of WRED green packet count";
+            type yang:counter64;
+        }
+        leaf green-discard-dropped-bytes {
+            description "Number of WRED green byte count";
+            type yang:counter64;
+        }
+        leaf yellow-discard-dropped-packets {
+            description "Number of WRED yellow packet count";
+            type yang:counter64;
+        }
+        leaf yellow-discard-dropped-bytes {
+            description "Number of WRED yellow packet count";
+            type yang:counter64;
+        }
+        leaf red-discard-dropped-packets {
+            description "Number of WRED red packet count";
+            type yang:counter64;
+        }
+        leaf red-discard-dropped-bytes {
+            description "Number of WRED red packet count";
+            type yang:counter64;
+        }
+        leaf discard-dropped-packets {
+            description "Number of WRED dropped packet count";
+            type yang:counter64;
+        }
+        leaf discard-dropped-bytes {
+            description "Number of WRED dropped packet bytes";
+            type yang:counter64;
+        }
+        leaf ether-in-pkts-64-octets {
+            description "Number of Ethernet receive packets of 64 octets";
+            type yang:counter64;
+        }
+        leaf ether-in-pkts-65-to-127-octets {
+            description "Number of Ethernet receive packets of 65 to 127 octets";
+            type yang:counter64;
+        }
+        leaf ether-in-pkts-128-to-255-octets {
+            description "Number of Ethernet receive packets of 128 to 255 octets";
+            type yang:counter64;
+        }
+        leaf ether-in-pkts-256-to-511-octets {
+            description " Number of Ethernet receive packets of 256 to 511 octets";
+            type yang:counter64;
+        }
+        leaf ether-in-pkts-512-to-1023-octets {
+            description "Number of Ethernet receive packets of 512 to 1023 octets";
+            type yang:counter64;
+        }
+        leaf ether-in-pkts-1024-to-1518-octets {
+            description "Number of Ethernet receive packets of 1024 to 1518 octets";
+            type yang:counter64;
+        }
+        leaf ether-in-pkts-1519-to-2047-octets {
+            description "Number of Ethernet receive packets of 1519 to 2047 octets";
+            type yang:counter64;
+        }
+        leaf ether-in-pkts-2048-to-4095-octets {
+            description "Number of Ethernet receive packets of 2047 to 4095 octets";
+            type yang:counter64;
+        }
+        leaf ether-in-pkts-4096-to-9216-octets {
+            description "Number of Ethernet receive packets of 4096 to 9216 octets";
+            type yang:counter64;
+        }
+        leaf ether-in-pkts-9217-to-16383-octets {
+            description "Number of Ethernet receive packets of 9217 to 16383 octets";
+            type yang:counter64;
+        }
+        leaf ether-out-pkts-64-octets {
+            description "Number of Ethernet transmit packets of 64 octets";
+            type yang:counter64;
+        }
+        leaf ether-out-pkts-65-to-127-octets {
+            description "Number of Ethernet transmit packets of 65 to 127 octets";
+            type yang:counter64;
+        }
+        leaf ether-out-pkts-128-to-255-octets {
+            description "Number of Ethernet transmit packets of 128 to 255 octets";
+            type yang:counter64;
+        }
+        leaf ether-out-pkts-256-to-511-octets {
+            description " Number of Ethernet transmit packets of 256 to 511 octets";
+            type yang:counter64;
+        }
+        leaf ether-out-pkts-512-to-1023-octets {
+            description "Number of Ethernet transmit packets of 512 to 1023 octets";
+            type yang:counter64;
+        }
+        leaf ether-out-pkts-1024-to-1518-octets {
+            description "Number of Ethernet transmit packets of 1024 to 1518 octets";
+            type yang:counter64;
+        }
+        leaf ether-out-pkts-1519-to-2047-octets {
+            description "Number of Ethernet transmit packets of 1519 to 2047 octets";
+            type yang:counter64;
+        }
+        leaf ether-out-pkts-2048-to-4095-octets {
+            description "Number of Ethernet transmit packets of 2047 to 4095 octets";
+            type yang:counter64;
+        }
+        leaf ether-out-pkts-4096-to-9216-octets {
+            description "Number of Ethernet transmit packets of 4096 to 9216 octets";
+            type yang:counter64;
+        }
+        leaf ether-out-pkts-9217-to-16383-octets {
+            description "Number of Ethernet transmit packets of 9217 to 16383 octets";
+            type yang:counter64;
+        }
+        leaf current-occupancy-bytes {
+            description "Current port occupancy in bytes";
+            type yang:counter64;
+        }
+        leaf watermark-bytes {
+            description "port occupancy watermark in bytes";
+            type yang:counter64;
+        }
+        leaf shared-current-occupancy-bytes {
+            description "current port shared occupancy in bytes";
+            type yang:counter64;
+        }
+        leaf shared-watermark-bytes {
+            description "port shared coccupancy watermark in bytes";
+            type yang:counter64;
+        }
+        leaf pause-rx-pkts {
+            description "number of pause frames received on the port";
+            type yang:counter64;
+        }
+        leaf pause-tx-pkts{
+            description "number of pause frames transmitted on the port";
+            type yang:counter64;
+        }
+        leaf pfc-0-rx-pkts{
+            description "PFC 0 RX packet counter";
+            type yang:counter64;
+        }
+        leaf pfc-0-tx-pkts{
+            description "PFC 0 TX packet counter";
+            type yang:counter64;
+        }
+        leaf pfc-1-rx-pkts{
+            description "PFC 1 RX packet counter";
+            type yang:counter64;
+        }
+        leaf pfc-1-tx-pkts{
+            description "PFC 1 TX packet counter";
+            type yang:counter64;
+        }
+        leaf pfc-2-rx-pkts{
+            description "PFC 2 RX packet counter";
+            type yang:counter64;
+        }
+        leaf pfc-2-tx-pkts{
+            description "PFC 2 TX packet counter";
+            type yang:counter64;
+        }
+        leaf pfc-3-rx-pkts{
+            description "PFC 3 RX packet counter";
+            type yang:counter64;
+        }
+        leaf pfc-3-tx-pkts{
+            description "PFC 3 TX packet counter";
+            type yang:counter64;
+        }
+        leaf pfc-4-rx-pkts{
+            description "PFC 4 RX packet counter";
+            type yang:counter64;
+        }
+        leaf pfc-4-tx-pkts{
+            description "PFC 4 TX packet counter";
+            type yang:counter64;
+        }
+        leaf pfc-5-rx-pkts{
+            description "PFC 5 RX packet counter";
+            type yang:counter64;
+        }
+        leaf pfc-5-tx-pkts{
+            description "PFC 5 TX packet counter";
+            type yang:counter64;
+        }
+        leaf pfc-6-rx-pkts{
+            description "PFC 6 RX packet counter";
+            type yang:counter64;
+        }
+        leaf pfc-6-tx-pkts{
+            description "PFC 6 TX packet counter";
+            type yang:counter64;
+        }
+        leaf pfc-7-rx-pkts{
+            description "PFC 7 RX packet counter";
+            type yang:counter64;
+        }
+        leaf pfc-7-tx-pkts{
+            description "PFC 7 TX packet counter";
+            type yang:counter64;
+        }
+        leaf tx-lpi-count {
+            type yang:counter64;
+            description
+                "Tx LPI event count";
+        }
+        leaf tx-lpi-duration {
+            type yang:counter64;
+            description
+                "Tx LPI duration";
+        }
+        leaf rx-lpi-count {
+            type yang:counter64;
+            description
+                "Rx LPI event count";
+        }
+        leaf rx-lpi-duration {
+            type yang:counter64;
+            description
+                "Rx LPI duration";
+        }
+
+    }
+
+    augment "/if:interfaces-state/if:interface/if:statistics" {
+        when "if:type = 'ianaift:l2vlan' or if:type = 'ianaift:l3vlan' or "
+           + "if:type = 'ianaift:softwareLoopback' or if:type = 'base-if:management'";
+
+        leaf in-pkts {
+          type yang:counter64;
+          description
+            "Total number of incoming packets";
+        }
+        leaf out-pkts {
+          type yang:counter64;
+          description
+            "Total number of outgoing packets";
+        }
+    }
+
+    augment "/if:interfaces-state/if:interface/if:statistics" {
+        when "if:type = 'ianaift:fibreChannel'";
+
+        leaf rx-bytes {
+          type yang:counter64;
+          description
+            "Total received bytes";
+        }
+        leaf rx-frames {
+          type yang:counter64;
+          description
+            "Total number of good frames received";
+        }
+        leaf rx-ucast-pkts {
+          type yang:counter64;
+          description
+            "Total number of unicast packets received";
+        }
+        leaf rx-bcast-pkts {
+          type yang:counter64;
+          description
+            "Total number of broadcast packets received";
+        }
+        leaf rx-invalid-crc {
+          type yang:counter64;
+          description
+            "Total number of packets(includes Class 2,3 and F) received
+                with invalid CRC";
+        }
+        leaf rx-frame-too-long {
+          type yang:counter64;
+          description
+            "Total number (includes Class 2, 3, F) of too long frames received";
+        }
+        leaf rx-frame-truncated {
+          type yang:counter64;
+          description
+            "Total number (includes Class 2, 3 and F)of truncated frames received";
+        }
+        leaf rx-link-fail {
+          type yang:counter64;
+          description
+            "Total number of link fail received";
+        }
+        leaf rx-loss-sync {
+          type yang:counter64;
+          description
+            "Total number of loss synchronizations received";
+        }
+        leaf class2-rx-good-frames {
+          type yang:counter64;
+          description
+            "Total number of class 2 good frames received";
+        }
+        leaf class3-rx-good-frames {
+          type yang:counter64;
+          description
+            "Total number of class 3 good frames received";
+        }
+        leaf rx-bb-credit0 {
+          type yang:counter64;
+          description
+            "The number of transitions into the rx BB credit zero state";
+        }
+        leaf rx-bb-credit0_drop {
+          type yang:counter64;
+          description
+            "The number packets dropped due to BB credit 0";
+        }
+        leaf rx-prim-seq-err {
+          type yang:counter64;
+          description
+            "Total number of frames with primitive sequence Protocol errors received";
+        }
+        leaf rx-lip-count {
+          type yang:counter64;
+          description
+            "Total number of LIP(Loop Initialization Primitive Sequence) Count";
+        }
+        leaf tx-bytes {
+          type yang:counter64;
+          description
+            "Total transmit bytes";
+        }
+        leaf tx-frames {
+          type yang:counter64;
+          description
+            "Total number of frames transmitted";
+        }
+        leaf tx-ucast-pkts {
+          type yang:counter64;
+          description
+            "Total number of unicast packets transmitted";
+        }
+        leaf tx-bcast-pkts {
+          type yang:counter64;
+          description
+            "Total number of non-unicast packets transmitted";
+        }
+        leaf class2-tx-frames {
+          type yang:counter64;
+          description
+            "Total number of class 2 frames transmitted";
+        }
+        leaf class3-tx-frames {
+          type yang:counter64;
+          description
+            "Total number of class 3 frames transmitted";
+        }
+        leaf tx-bb-credit0 {
+          type yang:counter64;
+          description
+            "FC port full buffer counter(0 transmit BB credit)";
+        }
+        leaf tx-oversize_frames {
+          type yang:counter64;
+          description
+            "Total number (including Class 2, 3 and F) of oversize packets
+                transmitted";
+        }
+        leaf total-errors {
+          type yang:counter64;
+          description
+            "Total number of errors, including rx and tx";
+        }
+
+    }
+
+    rpc clear-counters {
+      description "RPC for clearing interface counters. Input can be :
+                   1. Single interface name (or ifindex for base)
+                   2. All interfaces
+                   3. All interfaces of a particular type";
+      input {
+        choice intf-choice {
+          case all-intf-case {
+            leaf all-intf {
+              type enumeration {
+                enum "ALL" {
+                  value 1;
+                }
+                enum "ALL-ETH" {
+                  value 2;
+                }
+                enum "ALL-LAG" {
+                  value 3;
+                }
+                enum "ALL-VLAN" {
+                  value 4;
+                }
+                enum "ALL-LOOPBACK" {
+                  value 5;
+                }
+                enum "ALL-MGMT" {
+                  value 6;
+                }
+                enum "ALL-FC" {
+                  value 7;
+                }
+              }
+              description "All interfaces of all types or single type";
+            }
+          }
+          case ifname-case {
+            leaf ifname {
+              type if:interface-ref;
+              description "Interface name";
+            }
+          }
+          case ifindex-case {
+            leaf ifindex {
+              type int32;
+              description "Interface index";
+            }
+          }
+        }
+      }
+    }
+
+    rpc clear-eee-counters {
+        description "RPC for clearing 802.3az (EEE)interface counters. Input will be :
+                     all interfaces (all-intf = ALL), or
+                     a single interface name (or ifindex for base)";
+        input {
+            choice intf-choice {
+                case all-intf-case {
+                    leaf all-intf {
+                        type enumeration {
+                            enum "ALL" {
+                                value 1;
+                            }
+                        }
+                        description "All EEE interfaces";
+                    }
+                }
+                case ifname-case {
+                    leaf ifname {
+                        type if:interface-ref;
+                        description "Interface name";
+                    }
+                }
+                case ifindex-case {
+                    leaf ifindex {
+                        type int32;
+                        description "Interface index";
+                    }
+                }
+            }
+        }
+    }
+
+    rpc if-location-led {
+        description
+          "Set the interface location led";
+        input {
+          leaf ifname {
+            type if:interface-ref;
+            description
+              "Interface name";
+          }
+          leaf led-on {
+               type boolean;
+               description "Indicates led state requested";
+          }
+        }
+    }
+
+}

--- a/python-inocybe-openswitch/models/dell-yang-types.yang
+++ b/python-inocybe-openswitch/models/dell-yang-types.yang
@@ -1,0 +1,362 @@
+module dell-yang-types {
+  namespace "http://www.dellemc.com/networking/os10/dell-yang-types";
+  prefix common;
+
+  import ietf-inet-types {
+    prefix inet;
+  }
+
+  revision 2015-06-04 {
+    description
+      "Add scp,http,https to typedef protocol-name.";
+  }
+  revision 2015-03-10 {
+    description
+      "Initial revision.";
+  }
+
+  /*
+   * typedefs
+   */
+
+  typedef percent {
+    description
+      "percentage type";
+    type uint8 {
+      range "0 .. 100";
+    }
+    units "percent";
+  }
+
+  typedef xfloat {
+    type decimal64 {
+      fraction-digits 3;
+    }
+    description
+      "The decimal or float value type";
+  }
+
+  typedef log-intf-types {
+    type enumeration {
+      enum "logical" {
+        value 1;
+      }
+      enum "cpu" {
+        value 2;
+      }
+      enum "lag" {
+        value 3;
+      }
+      enum "null" {
+        value 4;
+      }
+      enum "loopback" {
+        value 5;
+      }
+      enum "port-channel" {
+        value 6;
+      }
+      enum "vlan" {
+        value 7;
+      }
+      enum "l2-tunnel" {
+        value 8;
+      }
+    }
+    description
+      "Defines the type of logical interfaces";
+  }
+
+  typedef phy-intf-types {
+    type enumeration {
+      enum "tengigabitethernet" {
+        value 1;
+      }
+      enum "fortyGigaBitEtnernet" {
+        value 2;
+      }
+      enum "gigaBitEthernet" {
+        value 3;
+      }
+    }
+    description
+      "Defines the type of physical interfaces";
+  }
+
+  typedef interface-types {
+    type union {
+      type phy-intf-types;
+      type log-intf-types;
+    }
+  }
+
+  typedef policy-name {
+    type string {
+      length "1..140";
+      pattern "(([^,=|&\"])|([\\w]))+";
+    }
+    description
+      "Name of the access group or list";
+  }
+
+  typedef ipv4-mask-or-prefix {
+    type union {
+      type inet:ipv4-address;
+      type inet:ipv4-prefix;
+    }
+  }
+
+  typedef ipv6-mask-or-prefix {
+    type union {
+      type inet:ipv6-address;
+      type inet:ipv6-prefix;
+    }
+  }
+
+  typedef ip-mask-or-prefix {
+    type union {
+      type ipv4-mask-or-prefix;
+      type ipv6-mask-or-prefix;
+    }
+  }
+
+  typedef as-number-dot {
+    type string {
+      pattern "((([0-9][0-9]{0,3})|([1-5][0-9]{4})|(6[0-4][0-9]{3})|(65[0-4][0-9]{2})|(655[0-2][0-9])|(6553[0-5]))\\.(([0-9][0-9]{0,3})|([1-5][0-9]{4})|(6[0-4][0-9]{3})|(65[0-4][0-9]{2})|(655[0-2][0-9])|(6553[0-5])))|([1-9][0-9]{0,8})|([1-3][0-9]{9})|(4[0-1][0-9]{8})|(42[0-8][0-9]{7})|(429[0-3][0-9]{6})|(4294[0-8][0-9]{5})|(42949[0-5][0-9]{4})|(429496[0-6][0-9]{3})|(4294967[0-1][0-9]{2})|(42949672[0-8][0-9])|(429496729[0-5])";
+    }
+    description
+      "The as-number type in dot format represents autonomous system numbers
+       which identify an Autonomous System.";
+  }
+
+  typedef interface-name {
+    type string {
+      length "0..255";
+    }
+    description
+      "Name of the interface as in ifName";
+  }
+
+  typedef admin-status {
+    type enumeration {
+      enum "admin-up" {
+        value 1;
+      }
+      enum "admin-down" {
+        value 2;
+      }
+    }
+    description
+      "The desired state of the interface.";
+  }
+
+  typedef oper-status {
+    type enumeration {
+      enum "unknown" {
+        value 1;
+      }
+      enum "up" {
+        value 2;
+      }
+      enum "down" {
+        value 3;
+      }
+      enum "testing" {
+        value 4;
+      }
+      enum "not-present" {
+        value 5;
+      }
+      enum "disabled" {
+        value 6;
+      }
+      enum "diag" {
+        value 7;
+      }
+      enum "linkup" {
+        value 8;
+      }
+    }
+    description
+      "The current operational state of the interface.";
+  }
+
+  typedef vrf-name {
+    type string {
+      length "0..31";
+    }
+    description
+      "The name of the vrf(virtual routing and forwarding).";
+  }
+
+  typedef ethertype {
+    type union {
+      type string {
+        length "3..4";
+        pattern "[6-9a-fA-F][0-9a-fA-F][0-9a-fA-f]";
+      }
+      type string {
+        length "3..4";
+        pattern "[1-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]";
+      }
+    }
+    description
+      "<600-FFFF>;;Ethertype hex value.";
+  }
+
+  typedef vlan-range {
+    type string {
+      length "0..255";
+      pattern "([0-9]+|[0-9]+-[0-9]+)(,([0-9]+|[0-9]+-[0-9]+))*";
+    }
+    description
+      "One vlan (1..4094) or a range separated by dash: 1-1 to 4094-4094";
+  }
+
+  typedef vlan-range-separated-by-comma {
+    type string {
+      length "0..255";
+      pattern "([0-9]+)|(([0-9]+)(,([0-9]+))*)";
+    }
+    description
+      "One vlan (1..4094) or a range separated by comma:1,2,3";
+  }
+
+  typedef vlan-name {
+    type string {
+      length "0..31";
+      pattern "([a-zA-Z])+([.]|[\\S])*";
+    }
+    description
+      "The name of VLAN.";
+  }
+
+  typedef vlan-id {
+    type uint16 {
+      range "1..4094";
+    }
+    description
+      "The number or id of VLAN.";
+  }
+
+  typedef direction-enumeration {
+    type enumeration {
+      enum "in" {
+        value 1;
+      }
+      enum "out" {
+        value 2;
+      }
+      enum "both" {
+        value 3;
+      }
+    }
+    description
+      "used to represent in or out direction.";
+  }
+
+  typedef vrf-id {
+    type uint32 {
+      range "1..512";
+    }
+    description
+      "vrf id value.";
+  }
+
+  typedef protocol-name {
+    type enumeration {
+      enum "bgp" {
+        value 1;
+      }
+      enum "dhcp" {
+        value 2;
+      }
+      enum "dhcp-relay" {
+        value 3;
+      }
+      enum "ftp" {
+        value 4;
+      }
+      enum "icmp" {
+        value 5;
+      }
+      enum "igmp" {
+        value 6;
+      }
+      enum "msdp" {
+        value 7;
+      }
+      enum "ntp" {
+        value 8;
+      }
+      enum "ospf" {
+        value 9;
+      }
+      enum "pim" {
+        value 10;
+      }
+      enum "rip" {
+        value 11;
+      }
+      enum "ssh" {
+        value 12;
+      }
+      enum "telnet" {
+        value 13;
+      }
+      enum "vrrp" {
+        value 14;
+      }
+      enum "ip" {
+        value 15;
+      }
+      enum "tcp" {
+        value 16;
+      }
+      enum "udp" {
+        value 17;
+      }
+      enum "ipv6" {
+        value 18;
+      }
+      enum "arp" {
+        value 19;
+      }
+      enum "bridging" {
+        value 20;
+      }
+      enum "cdp" {
+        value 21;
+      }
+      enum "is-is" {
+        value 22;
+      }
+      enum "scp" {
+        value 23;
+      }
+      enum "http" {
+        value 24;
+      }
+      enum "https" {
+        value 25;
+      }
+      enum "frrp" {
+        value 26;
+      }
+      enum "gvrp" {
+        value 27;
+      }
+      enum "lacp" {
+        value 28;
+      }
+      enum "lldp" {
+        value 29;
+      }
+      enum "stp" {
+        value 30;
+      }
+    }
+    description
+      "List of protocols names.";
+  }
+}

--- a/python-inocybe-openswitch/models/iana-if-type.yang
+++ b/python-inocybe-openswitch/models/iana-if-type.yang
@@ -1,0 +1,1547 @@
+module iana-if-type {
+  namespace "urn:ietf:params:xml:ns:yang:iana-if-type";
+  prefix ianaift;
+
+  import ietf-interfaces {
+    prefix if;
+  }
+
+  organization "IANA";
+  contact
+    "        Internet Assigned Numbers Authority
+
+     Postal: ICANN
+             4676 Admiralty Way, Suite 330
+             Marina del Rey, CA 90292
+
+     Tel:    +1 310 823 9358
+     <mailto:iana@iana.org>";
+  description
+    "This YANG module defines YANG identities for IANA-registered
+     interface types.
+
+     This YANG module is maintained by IANA and reflects the
+     'ifType definitions' registry.
+
+     The latest revision of this YANG module can be obtained from
+     the IANA web site.
+
+     Requests for new values should be made to IANA via
+     email (iana@iana.org).
+
+     Copyright (c) 2014 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     The initial version of this YANG module is part of RFC 7224;
+     see the RFC itself for full legal notices.";
+    reference
+      "IANA 'ifType definitions' registry.
+       <http://www.iana.org/assignments/smi-numbers>";
+
+  revision 2014-05-08 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 7224: IANA Interface Type YANG Module";
+  }
+
+  identity iana-interface-type {
+    base if:interface-type;
+    description
+      "This identity is used as a base for all interface types
+       defined in the 'ifType definitions' registry.";
+  }
+
+
+
+
+
+
+  identity other {
+    base iana-interface-type;
+  }
+  identity regular1822 {
+    base iana-interface-type;
+  }
+  identity hdh1822 {
+    base iana-interface-type;
+  }
+  identity ddnX25 {
+    base iana-interface-type;
+  }
+  identity rfc877x25 {
+    base iana-interface-type;
+    reference
+      "RFC 1382 - SNMP MIB Extension for the X.25 Packet Layer";
+  }
+  identity ethernetCsmacd {
+    base iana-interface-type;
+    description
+      "For all Ethernet-like interfaces, regardless of speed,
+       as per RFC 3635.";
+    reference
+      "RFC 3635 - Definitions of Managed Objects for the
+                  Ethernet-like Interface Types";
+  }
+  identity iso88023Csmacd {
+    base iana-interface-type;
+    status deprecated;
+    description
+      "Deprecated via RFC 3635.
+       Use ethernetCsmacd(6) instead.";
+    reference
+      "RFC 3635 - Definitions of Managed Objects for the
+                  Ethernet-like Interface Types";
+  }
+  identity iso88024TokenBus {
+    base iana-interface-type;
+  }
+  identity iso88025TokenRing {
+    base iana-interface-type;
+  }
+  identity iso88026Man {
+    base iana-interface-type;
+  }
+  identity starLan {
+    base iana-interface-type;
+    status deprecated;
+    description
+      "Deprecated via RFC 3635.
+       Use ethernetCsmacd(6) instead.";
+    reference
+      "RFC 3635 - Definitions of Managed Objects for the
+                  Ethernet-like Interface Types";
+  }
+  identity proteon10Mbit {
+    base iana-interface-type;
+  }
+  identity proteon80Mbit {
+    base iana-interface-type;
+  }
+  identity hyperchannel {
+    base iana-interface-type;
+  }
+  identity fddi {
+    base iana-interface-type;
+    reference
+      "RFC 1512 - FDDI Management Information Base";
+  }
+  identity lapb {
+    base iana-interface-type;
+    reference
+      "RFC 1381 - SNMP MIB Extension for X.25 LAPB";
+  }
+  identity sdlc {
+    base iana-interface-type;
+  }
+  identity ds1 {
+    base iana-interface-type;
+    description
+      "DS1-MIB.";
+    reference
+      "RFC 4805 - Definitions of Managed Objects for the
+                  DS1, J1, E1, DS2, and E2 Interface Types";
+  }
+  identity e1 {
+    base iana-interface-type;
+    status obsolete;
+    description
+      "Obsolete; see DS1-MIB.";
+    reference
+      "RFC 4805 - Definitions of Managed Objects for the
+                  DS1, J1, E1, DS2, and E2 Interface Types";
+  }
+
+
+  identity basicISDN {
+    base iana-interface-type;
+    description
+      "No longer used.  See also RFC 2127.";
+  }
+  identity primaryISDN {
+    base iana-interface-type;
+    description
+      "No longer used.  See also RFC 2127.";
+  }
+  identity propPointToPointSerial {
+    base iana-interface-type;
+    description
+      "Proprietary serial.";
+  }
+  identity ppp {
+    base iana-interface-type;
+  }
+  identity softwareLoopback {
+    base iana-interface-type;
+  }
+  identity eon {
+    base iana-interface-type;
+    description
+      "CLNP over IP.";
+  }
+  identity ethernet3Mbit {
+    base iana-interface-type;
+  }
+  identity nsip {
+    base iana-interface-type;
+    description
+      "XNS over IP.";
+  }
+  identity slip {
+    base iana-interface-type;
+    description
+      "Generic SLIP.";
+  }
+  identity ultra {
+    base iana-interface-type;
+    description
+      "Ultra Technologies.";
+  }
+  identity ds3 {
+    base iana-interface-type;
+    description
+      "DS3-MIB.";
+    reference
+      "RFC 3896 - Definitions of Managed Objects for the
+                  DS3/E3 Interface Type";
+  }
+  identity sip {
+    base iana-interface-type;
+    description
+      "SMDS, coffee.";
+    reference
+      "RFC 1694 - Definitions of Managed Objects for SMDS
+                  Interfaces using SMIv2";
+  }
+  identity frameRelay {
+    base iana-interface-type;
+    description
+      "DTE only.";
+    reference
+      "RFC 2115 - Management Information Base for Frame Relay
+                  DTEs Using SMIv2";
+  }
+  identity rs232 {
+    base iana-interface-type;
+    reference
+      "RFC 1659 - Definitions of Managed Objects for RS-232-like
+                  Hardware Devices using SMIv2";
+  }
+  identity para {
+    base iana-interface-type;
+    description
+      "Parallel-port.";
+    reference
+      "RFC 1660 - Definitions of Managed Objects for
+                  Parallel-printer-like Hardware Devices using
+                  SMIv2";
+  }
+  identity arcnet {
+    base iana-interface-type;
+    description
+      "ARCnet.";
+  }
+  identity arcnetPlus {
+    base iana-interface-type;
+    description
+      "ARCnet Plus.";
+  }
+
+
+
+  identity atm {
+    base iana-interface-type;
+    description
+      "ATM cells.";
+  }
+  identity miox25 {
+    base iana-interface-type;
+    reference
+      "RFC 1461 - SNMP MIB extension for Multiprotocol
+                  Interconnect over X.25";
+  }
+  identity sonet {
+    base iana-interface-type;
+    description
+      "SONET or SDH.";
+  }
+  identity x25ple {
+    base iana-interface-type;
+    reference
+      "RFC 2127 - ISDN Management Information Base using SMIv2";
+  }
+  identity iso88022llc {
+    base iana-interface-type;
+  }
+  identity localTalk {
+    base iana-interface-type;
+  }
+  identity smdsDxi {
+    base iana-interface-type;
+  }
+  identity frameRelayService {
+    base iana-interface-type;
+    description
+      "FRNETSERV-MIB.";
+    reference
+      "RFC 2954 - Definitions of Managed Objects for Frame
+                  Relay Service";
+  }
+  identity v35 {
+    base iana-interface-type;
+  }
+  identity hssi {
+    base iana-interface-type;
+  }
+  identity hippi {
+    base iana-interface-type;
+  }
+
+  identity modem {
+    base iana-interface-type;
+    description
+      "Generic modem.";
+  }
+  identity aal5 {
+    base iana-interface-type;
+    description
+      "AAL5 over ATM.";
+  }
+  identity sonetPath {
+    base iana-interface-type;
+  }
+  identity sonetVT {
+    base iana-interface-type;
+  }
+  identity smdsIcip {
+    base iana-interface-type;
+    description
+      "SMDS InterCarrier Interface.";
+  }
+  identity propVirtual {
+    base iana-interface-type;
+    description
+      "Proprietary virtual/internal.";
+    reference
+      "RFC 2863 - The Interfaces Group MIB";
+  }
+  identity propMultiplexor {
+    base iana-interface-type;
+    description
+      "Proprietary multiplexing.";
+    reference
+      "RFC 2863 - The Interfaces Group MIB";
+  }
+  identity ieee80212 {
+    base iana-interface-type;
+    description
+      "100BaseVG.";
+  }
+  identity fibreChannel {
+    base iana-interface-type;
+    description
+      "Fibre Channel.";
+  }
+
+
+
+  identity hippiInterface {
+    base iana-interface-type;
+    description
+      "HIPPI interfaces.";
+  }
+  identity frameRelayInterconnect {
+    base iana-interface-type;
+    status obsolete;
+    description
+      "Obsolete; use either
+       frameRelay(32) or frameRelayService(44).";
+  }
+  identity aflane8023 {
+    base iana-interface-type;
+    description
+      "ATM Emulated LAN for 802.3.";
+  }
+  identity aflane8025 {
+    base iana-interface-type;
+    description
+      "ATM Emulated LAN for 802.5.";
+  }
+  identity cctEmul {
+    base iana-interface-type;
+    description
+      "ATM Emulated circuit.";
+  }
+  identity fastEther {
+    base iana-interface-type;
+    status deprecated;
+    description
+      "Obsoleted via RFC 3635.
+       ethernetCsmacd(6) should be used instead.";
+    reference
+      "RFC 3635 - Definitions of Managed Objects for the
+                  Ethernet-like Interface Types";
+  }
+  identity isdn {
+    base iana-interface-type;
+    description
+      "ISDN and X.25.";
+    reference
+      "RFC 1356 - Multiprotocol Interconnect on X.25 and ISDN
+                  in the Packet Mode";
+  }
+
+
+
+  identity v11 {
+    base iana-interface-type;
+    description
+      "CCITT V.11/X.21.";
+  }
+  identity v36 {
+    base iana-interface-type;
+    description
+      "CCITT V.36.";
+  }
+  identity g703at64k {
+    base iana-interface-type;
+    description
+      "CCITT G703 at 64Kbps.";
+  }
+  identity g703at2mb {
+    base iana-interface-type;
+    status obsolete;
+    description
+      "Obsolete; see DS1-MIB.";
+  }
+  identity qllc {
+    base iana-interface-type;
+    description
+      "SNA QLLC.";
+  }
+  identity fastEtherFX {
+    base iana-interface-type;
+    status deprecated;
+    description
+      "Obsoleted via RFC 3635.
+       ethernetCsmacd(6) should be used instead.";
+    reference
+      "RFC 3635 - Definitions of Managed Objects for the
+                  Ethernet-like Interface Types";
+  }
+  identity channel {
+    base iana-interface-type;
+    description
+      "Channel.";
+  }
+  identity ieee80211 {
+    base iana-interface-type;
+    description
+      "Radio spread spectrum.";
+  }
+  identity ibm370parChan {
+    base iana-interface-type;
+    description
+      "IBM System 360/370 OEMI Channel.";
+  }
+  identity escon {
+    base iana-interface-type;
+    description
+      "IBM Enterprise Systems Connection.";
+  }
+  identity dlsw {
+    base iana-interface-type;
+    description
+      "Data Link Switching.";
+  }
+  identity isdns {
+    base iana-interface-type;
+    description
+      "ISDN S/T interface.";
+  }
+  identity isdnu {
+    base iana-interface-type;
+    description
+      "ISDN U interface.";
+  }
+  identity lapd {
+    base iana-interface-type;
+    description
+      "Link Access Protocol D.";
+  }
+  identity ipSwitch {
+    base iana-interface-type;
+    description
+      "IP Switching Objects.";
+  }
+  identity rsrb {
+    base iana-interface-type;
+    description
+      "Remote Source Route Bridging.";
+  }
+  identity atmLogical {
+    base iana-interface-type;
+    description
+      "ATM Logical Port.";
+    reference
+      "RFC 3606 - Definitions of Supplemental Managed Objects
+                  for ATM Interface";
+  }
+  identity ds0 {
+    base iana-interface-type;
+    description
+      "Digital Signal Level 0.";
+    reference
+      "RFC 2494 - Definitions of Managed Objects for the DS0
+                  and DS0 Bundle Interface Type";
+  }
+  identity ds0Bundle {
+    base iana-interface-type;
+    description
+      "Group of ds0s on the same ds1.";
+    reference
+      "RFC 2494 - Definitions of Managed Objects for the DS0
+                  and DS0 Bundle Interface Type";
+  }
+  identity bsc {
+    base iana-interface-type;
+    description
+      "Bisynchronous Protocol.";
+  }
+  identity async {
+    base iana-interface-type;
+    description
+      "Asynchronous Protocol.";
+  }
+  identity cnr {
+    base iana-interface-type;
+    description
+      "Combat Net Radio.";
+  }
+  identity iso88025Dtr {
+    base iana-interface-type;
+    description
+      "ISO 802.5r DTR.";
+  }
+  identity eplrs {
+    base iana-interface-type;
+    description
+      "Ext Pos Loc Report Sys.";
+  }
+  identity arap {
+    base iana-interface-type;
+    description
+      "Appletalk Remote Access Protocol.";
+  }
+  identity propCnls {
+    base iana-interface-type;
+    description
+      "Proprietary Connectionless Protocol.";
+  }
+  identity hostPad {
+    base iana-interface-type;
+    description
+      "CCITT-ITU X.29 PAD Protocol.";
+  }
+  identity termPad {
+    base iana-interface-type;
+    description
+      "CCITT-ITU X.3 PAD Facility.";
+  }
+  identity frameRelayMPI {
+    base iana-interface-type;
+    description
+      "Multiproto Interconnect over FR.";
+  }
+  identity x213 {
+    base iana-interface-type;
+    description
+      "CCITT-ITU X213.";
+  }
+  identity adsl {
+    base iana-interface-type;
+    description
+      "Asymmetric Digital Subscriber Loop.";
+  }
+  identity radsl {
+    base iana-interface-type;
+    description
+      "Rate-Adapt. Digital Subscriber Loop.";
+  }
+  identity sdsl {
+    base iana-interface-type;
+    description
+      "Symmetric Digital Subscriber Loop.";
+  }
+  identity vdsl {
+    base iana-interface-type;
+    description
+      "Very H-Speed Digital Subscrib. Loop.";
+  }
+  identity iso88025CRFPInt {
+    base iana-interface-type;
+    description
+      "ISO 802.5 CRFP.";
+  }
+  identity myrinet {
+    base iana-interface-type;
+    description
+      "Myricom Myrinet.";
+  }
+  identity voiceEM {
+    base iana-interface-type;
+    description
+      "Voice recEive and transMit.";
+  }
+  identity voiceFXO {
+    base iana-interface-type;
+    description
+      "Voice Foreign Exchange Office.";
+  }
+  identity voiceFXS {
+    base iana-interface-type;
+    description
+      "Voice Foreign Exchange Station.";
+  }
+  identity voiceEncap {
+    base iana-interface-type;
+    description
+      "Voice encapsulation.";
+  }
+  identity voiceOverIp {
+    base iana-interface-type;
+    description
+      "Voice over IP encapsulation.";
+  }
+  identity atmDxi {
+    base iana-interface-type;
+    description
+      "ATM DXI.";
+  }
+  identity atmFuni {
+    base iana-interface-type;
+    description
+      "ATM FUNI.";
+  }
+  identity atmIma {
+    base iana-interface-type;
+    description
+      "ATM IMA.";
+  }
+  identity pppMultilinkBundle {
+    base iana-interface-type;
+    description
+      "PPP Multilink Bundle.";
+  }
+  identity ipOverCdlc {
+    base iana-interface-type;
+    description
+      "IBM ipOverCdlc.";
+  }
+  identity ipOverClaw {
+    base iana-interface-type;
+    description
+      "IBM Common Link Access to Workstn.";
+  }
+  identity stackToStack {
+    base iana-interface-type;
+    description
+      "IBM stackToStack.";
+  }
+  identity virtualIpAddress {
+    base iana-interface-type;
+    description
+      "IBM VIPA.";
+  }
+  identity mpc {
+    base iana-interface-type;
+    description
+      "IBM multi-protocol channel support.";
+  }
+  identity ipOverAtm {
+    base iana-interface-type;
+    description
+      "IBM ipOverAtm.";
+    reference
+      "RFC 2320 - Definitions of Managed Objects for Classical IP
+                  and ARP Over ATM Using SMIv2 (IPOA-MIB)";
+  }
+  identity iso88025Fiber {
+    base iana-interface-type;
+    description
+      "ISO 802.5j Fiber Token Ring.";
+  }
+  identity tdlc {
+    base iana-interface-type;
+    description
+      "IBM twinaxial data link control.";
+  }
+  identity gigabitEthernet {
+    base iana-interface-type;
+    status deprecated;
+
+
+    description
+      "Obsoleted via RFC 3635.
+       ethernetCsmacd(6) should be used instead.";
+    reference
+      "RFC 3635 - Definitions of Managed Objects for the
+                  Ethernet-like Interface Types";
+  }
+  identity hdlc {
+    base iana-interface-type;
+    description
+      "HDLC.";
+  }
+  identity lapf {
+    base iana-interface-type;
+    description
+      "LAP F.";
+  }
+  identity v37 {
+    base iana-interface-type;
+    description
+      "V.37.";
+  }
+  identity x25mlp {
+    base iana-interface-type;
+    description
+      "Multi-Link Protocol.";
+  }
+  identity x25huntGroup {
+    base iana-interface-type;
+    description
+      "X25 Hunt Group.";
+  }
+  identity transpHdlc {
+    base iana-interface-type;
+    description
+      "Transp HDLC.";
+  }
+  identity interleave {
+    base iana-interface-type;
+    description
+      "Interleave channel.";
+  }
+  identity fast {
+    base iana-interface-type;
+    description
+      "Fast channel.";
+  }
+
+  identity ip {
+    base iana-interface-type;
+    description
+      "IP (for APPN HPR in IP networks).";
+  }
+  identity docsCableMaclayer {
+    base iana-interface-type;
+    description
+      "CATV Mac Layer.";
+  }
+  identity docsCableDownstream {
+    base iana-interface-type;
+    description
+      "CATV Downstream interface.";
+  }
+  identity docsCableUpstream {
+    base iana-interface-type;
+    description
+      "CATV Upstream interface.";
+  }
+  identity a12MppSwitch {
+    base iana-interface-type;
+    description
+      "Avalon Parallel Processor.";
+  }
+  identity tunnel {
+    base iana-interface-type;
+    description
+      "Encapsulation interface.";
+  }
+  identity coffee {
+    base iana-interface-type;
+    description
+      "Coffee pot.";
+    reference
+      "RFC 2325 - Coffee MIB";
+  }
+  identity ces {
+    base iana-interface-type;
+    description
+      "Circuit Emulation Service.";
+  }
+  identity atmSubInterface {
+    base iana-interface-type;
+    description
+      "ATM Sub Interface.";
+  }
+
+  identity l2vlan {
+    base iana-interface-type;
+    description
+      "Layer 2 Virtual LAN using 802.1Q.";
+  }
+  identity l3ipvlan {
+    base iana-interface-type;
+    description
+      "Layer 3 Virtual LAN using IP.";
+  }
+  identity l3ipxvlan {
+    base iana-interface-type;
+    description
+      "Layer 3 Virtual LAN using IPX.";
+  }
+  identity digitalPowerline {
+    base iana-interface-type;
+    description
+      "IP over Power Lines.";
+  }
+  identity mediaMailOverIp {
+    base iana-interface-type;
+    description
+      "Multimedia Mail over IP.";
+  }
+  identity dtm {
+    base iana-interface-type;
+    description
+      "Dynamic synchronous Transfer Mode.";
+  }
+  identity dcn {
+    base iana-interface-type;
+    description
+      "Data Communications Network.";
+  }
+  identity ipForward {
+    base iana-interface-type;
+    description
+      "IP Forwarding Interface.";
+  }
+  identity msdsl {
+    base iana-interface-type;
+    description
+      "Multi-rate Symmetric DSL.";
+  }
+  identity ieee1394 {
+    base iana-interface-type;
+
+    description
+      "IEEE1394 High Performance Serial Bus.";
+  }
+  identity if-gsn {
+    base iana-interface-type;
+    description
+      "HIPPI-6400.";
+  }
+  identity dvbRccMacLayer {
+    base iana-interface-type;
+    description
+      "DVB-RCC MAC Layer.";
+  }
+  identity dvbRccDownstream {
+    base iana-interface-type;
+    description
+      "DVB-RCC Downstream Channel.";
+  }
+  identity dvbRccUpstream {
+    base iana-interface-type;
+    description
+      "DVB-RCC Upstream Channel.";
+  }
+  identity atmVirtual {
+    base iana-interface-type;
+    description
+      "ATM Virtual Interface.";
+  }
+  identity mplsTunnel {
+    base iana-interface-type;
+    description
+      "MPLS Tunnel Virtual Interface.";
+  }
+  identity srp {
+    base iana-interface-type;
+    description
+      "Spatial Reuse Protocol.";
+  }
+  identity voiceOverAtm {
+    base iana-interface-type;
+    description
+      "Voice over ATM.";
+  }
+  identity voiceOverFrameRelay {
+    base iana-interface-type;
+    description
+      "Voice Over Frame Relay.";
+  }
+  identity idsl {
+    base iana-interface-type;
+    description
+      "Digital Subscriber Loop over ISDN.";
+  }
+  identity compositeLink {
+    base iana-interface-type;
+    description
+      "Avici Composite Link Interface.";
+  }
+  identity ss7SigLink {
+    base iana-interface-type;
+    description
+      "SS7 Signaling Link.";
+  }
+  identity propWirelessP2P {
+    base iana-interface-type;
+    description
+      "Prop. P2P wireless interface.";
+  }
+  identity frForward {
+    base iana-interface-type;
+    description
+      "Frame Forward Interface.";
+  }
+  identity rfc1483 {
+    base iana-interface-type;
+    description
+      "Multiprotocol over ATM AAL5.";
+    reference
+      "RFC 1483 - Multiprotocol Encapsulation over ATM
+                  Adaptation Layer 5";
+  }
+  identity usb {
+    base iana-interface-type;
+    description
+      "USB Interface.";
+  }
+  identity ieee8023adLag {
+    base iana-interface-type;
+    description
+      "IEEE 802.3ad Link Aggregate.";
+  }
+  identity bgppolicyaccounting {
+    base iana-interface-type;
+    description
+      "BGP Policy Accounting.";
+  }
+  identity frf16MfrBundle {
+    base iana-interface-type;
+    description
+      "FRF.16 Multilink Frame Relay.";
+  }
+  identity h323Gatekeeper {
+    base iana-interface-type;
+    description
+      "H323 Gatekeeper.";
+  }
+  identity h323Proxy {
+    base iana-interface-type;
+    description
+      "H323 Voice and Video Proxy.";
+  }
+  identity mpls {
+    base iana-interface-type;
+    description
+      "MPLS.";
+  }
+  identity mfSigLink {
+    base iana-interface-type;
+    description
+      "Multi-frequency signaling link.";
+  }
+  identity hdsl2 {
+    base iana-interface-type;
+    description
+      "High Bit-Rate DSL - 2nd generation.";
+  }
+  identity shdsl {
+    base iana-interface-type;
+    description
+      "Multirate HDSL2.";
+  }
+  identity ds1FDL {
+    base iana-interface-type;
+    description
+      "Facility Data Link (4Kbps) on a DS1.";
+  }
+  identity pos {
+    base iana-interface-type;
+    description
+      "Packet over SONET/SDH Interface.";
+  }
+
+
+
+  identity dvbAsiIn {
+    base iana-interface-type;
+    description
+      "DVB-ASI Input.";
+  }
+  identity dvbAsiOut {
+    base iana-interface-type;
+    description
+      "DVB-ASI Output.";
+  }
+  identity plc {
+    base iana-interface-type;
+    description
+      "Power Line Communications.";
+  }
+  identity nfas {
+    base iana-interface-type;
+    description
+      "Non-Facility Associated Signaling.";
+  }
+  identity tr008 {
+    base iana-interface-type;
+    description
+      "TR008.";
+  }
+  identity gr303RDT {
+    base iana-interface-type;
+    description
+      "Remote Digital Terminal.";
+  }
+  identity gr303IDT {
+    base iana-interface-type;
+    description
+      "Integrated Digital Terminal.";
+  }
+  identity isup {
+    base iana-interface-type;
+    description
+      "ISUP.";
+  }
+  identity propDocsWirelessMaclayer {
+    base iana-interface-type;
+    description
+      "Cisco proprietary Maclayer.";
+  }
+
+
+
+  identity propDocsWirelessDownstream {
+    base iana-interface-type;
+    description
+      "Cisco proprietary Downstream.";
+  }
+  identity propDocsWirelessUpstream {
+    base iana-interface-type;
+    description
+      "Cisco proprietary Upstream.";
+  }
+  identity hiperlan2 {
+    base iana-interface-type;
+    description
+      "HIPERLAN Type 2 Radio Interface.";
+  }
+  identity propBWAp2Mp {
+    base iana-interface-type;
+    description
+      "PropBroadbandWirelessAccesspt2Multipt (use of this value
+       for IEEE 802.16 WMAN interfaces as per IEEE Std 802.16f
+       is deprecated, and ieee80216WMAN(237) should be used
+       instead).";
+  }
+  identity sonetOverheadChannel {
+    base iana-interface-type;
+    description
+      "SONET Overhead Channel.";
+  }
+  identity digitalWrapperOverheadChannel {
+    base iana-interface-type;
+    description
+      "Digital Wrapper.";
+  }
+  identity aal2 {
+    base iana-interface-type;
+    description
+      "ATM adaptation layer 2.";
+  }
+  identity radioMAC {
+    base iana-interface-type;
+    description
+      "MAC layer over radio links.";
+  }
+  identity atmRadio {
+    base iana-interface-type;
+    description
+      "ATM over radio links.";
+  }
+  identity imt {
+    base iana-interface-type;
+    description
+      "Inter-Machine Trunks.";
+  }
+  identity mvl {
+    base iana-interface-type;
+    description
+      "Multiple Virtual Lines DSL.";
+  }
+  identity reachDSL {
+    base iana-interface-type;
+    description
+      "Long Reach DSL.";
+  }
+  identity frDlciEndPt {
+    base iana-interface-type;
+    description
+      "Frame Relay DLCI End Point.";
+  }
+  identity atmVciEndPt {
+    base iana-interface-type;
+    description
+      "ATM VCI End Point.";
+  }
+  identity opticalChannel {
+    base iana-interface-type;
+    description
+      "Optical Channel.";
+  }
+  identity opticalTransport {
+    base iana-interface-type;
+    description
+      "Optical Transport.";
+  }
+  identity propAtm {
+    base iana-interface-type;
+    description
+      "Proprietary ATM.";
+  }
+  identity voiceOverCable {
+    base iana-interface-type;
+    description
+      "Voice Over Cable Interface.";
+  }
+
+
+
+  identity infiniband {
+    base iana-interface-type;
+    description
+      "Infiniband.";
+  }
+  identity teLink {
+    base iana-interface-type;
+    description
+      "TE Link.";
+  }
+  identity q2931 {
+    base iana-interface-type;
+    description
+      "Q.2931.";
+  }
+  identity virtualTg {
+    base iana-interface-type;
+    description
+      "Virtual Trunk Group.";
+  }
+  identity sipTg {
+    base iana-interface-type;
+    description
+      "SIP Trunk Group.";
+  }
+  identity sipSig {
+    base iana-interface-type;
+    description
+      "SIP Signaling.";
+  }
+  identity docsCableUpstreamChannel {
+    base iana-interface-type;
+    description
+      "CATV Upstream Channel.";
+  }
+  identity econet {
+    base iana-interface-type;
+    description
+      "Acorn Econet.";
+  }
+  identity pon155 {
+    base iana-interface-type;
+    description
+      "FSAN 155Mb Symetrical PON interface.";
+  }
+
+
+
+  identity pon622 {
+    base iana-interface-type;
+    description
+      "FSAN 622Mb Symetrical PON interface.";
+  }
+  identity bridge {
+    base iana-interface-type;
+    description
+      "Transparent bridge interface.";
+  }
+  identity linegroup {
+    base iana-interface-type;
+    description
+      "Interface common to multiple lines.";
+  }
+  identity voiceEMFGD {
+    base iana-interface-type;
+    description
+      "Voice E&M Feature Group D.";
+  }
+  identity voiceFGDEANA {
+    base iana-interface-type;
+    description
+      "Voice FGD Exchange Access North American.";
+  }
+  identity voiceDID {
+    base iana-interface-type;
+    description
+      "Voice Direct Inward Dialing.";
+  }
+  identity mpegTransport {
+    base iana-interface-type;
+    description
+      "MPEG transport interface.";
+  }
+  identity sixToFour {
+    base iana-interface-type;
+    status deprecated;
+    description
+      "6to4 interface (DEPRECATED).";
+    reference
+      "RFC 4087 - IP Tunnel MIB";
+  }
+  identity gtp {
+    base iana-interface-type;
+    description
+      "GTP (GPRS Tunneling Protocol).";
+  }
+  identity pdnEtherLoop1 {
+    base iana-interface-type;
+    description
+      "Paradyne EtherLoop 1.";
+  }
+  identity pdnEtherLoop2 {
+    base iana-interface-type;
+    description
+      "Paradyne EtherLoop 2.";
+  }
+  identity opticalChannelGroup {
+    base iana-interface-type;
+    description
+      "Optical Channel Group.";
+  }
+  identity homepna {
+    base iana-interface-type;
+    description
+      "HomePNA ITU-T G.989.";
+  }
+  identity gfp {
+    base iana-interface-type;
+    description
+      "Generic Framing Procedure (GFP).";
+  }
+  identity ciscoISLvlan {
+    base iana-interface-type;
+    description
+      "Layer 2 Virtual LAN using Cisco ISL.";
+  }
+  identity actelisMetaLOOP {
+    base iana-interface-type;
+    description
+      "Acteleis proprietary MetaLOOP High Speed Link.";
+  }
+  identity fcipLink {
+    base iana-interface-type;
+    description
+      "FCIP Link.";
+  }
+  identity rpr {
+    base iana-interface-type;
+    description
+      "Resilient Packet Ring Interface Type.";
+  }
+
+
+
+  identity qam {
+    base iana-interface-type;
+    description
+      "RF Qam Interface.";
+  }
+  identity lmp {
+    base iana-interface-type;
+    description
+      "Link Management Protocol.";
+    reference
+      "RFC 4327 - Link Management Protocol (LMP) Management
+                  Information Base (MIB)";
+  }
+  identity cblVectaStar {
+    base iana-interface-type;
+    description
+      "Cambridge Broadband Networks Limited VectaStar.";
+  }
+  identity docsCableMCmtsDownstream {
+    base iana-interface-type;
+    description
+      "CATV Modular CMTS Downstream Interface.";
+  }
+  identity adsl2 {
+    base iana-interface-type;
+    status deprecated;
+    description
+      "Asymmetric Digital Subscriber Loop Version 2
+       (DEPRECATED/OBSOLETED - please use adsl2plus(238)
+       instead).";
+    reference
+      "RFC 4706 - Definitions of Managed Objects for Asymmetric
+                  Digital Subscriber Line 2 (ADSL2)";
+  }
+  identity macSecControlledIF {
+    base iana-interface-type;
+    description
+      "MACSecControlled.";
+  }
+  identity macSecUncontrolledIF {
+    base iana-interface-type;
+    description
+      "MACSecUncontrolled.";
+  }
+  identity aviciOpticalEther {
+    base iana-interface-type;
+    description
+      "Avici Optical Ethernet Aggregate.";
+  }
+  identity atmbond {
+    base iana-interface-type;
+    description
+      "atmbond.";
+  }
+  identity voiceFGDOS {
+    base iana-interface-type;
+    description
+      "Voice FGD Operator Services.";
+  }
+  identity mocaVersion1 {
+    base iana-interface-type;
+    description
+      "MultiMedia over Coax Alliance (MoCA) Interface
+       as documented in information provided privately to IANA.";
+  }
+  identity ieee80216WMAN {
+    base iana-interface-type;
+    description
+      "IEEE 802.16 WMAN interface.";
+  }
+  identity adsl2plus {
+    base iana-interface-type;
+    description
+      "Asymmetric Digital Subscriber Loop Version 2 -
+       Version 2 Plus and all variants.";
+  }
+  identity dvbRcsMacLayer {
+    base iana-interface-type;
+    description
+      "DVB-RCS MAC Layer.";
+    reference
+      "RFC 5728 - The SatLabs Group DVB-RCS MIB";
+  }
+  identity dvbTdm {
+    base iana-interface-type;
+    description
+      "DVB Satellite TDM.";
+    reference
+      "RFC 5728 - The SatLabs Group DVB-RCS MIB";
+  }
+  identity dvbRcsTdma {
+    base iana-interface-type;
+    description
+      "DVB-RCS TDMA.";
+    reference
+      "RFC 5728 - The SatLabs Group DVB-RCS MIB";
+  }
+  identity x86Laps {
+    base iana-interface-type;
+    description
+      "LAPS based on ITU-T X.86/Y.1323.";
+  }
+  identity wwanPP {
+    base iana-interface-type;
+    description
+      "3GPP WWAN.";
+  }
+  identity wwanPP2 {
+    base iana-interface-type;
+    description
+      "3GPP2 WWAN.";
+  }
+  identity voiceEBS {
+    base iana-interface-type;
+    description
+      "Voice P-phone EBS physical interface.";
+  }
+  identity ifPwType {
+    base iana-interface-type;
+    description
+      "Pseudowire interface type.";
+    reference
+      "RFC 5601 - Pseudowire (PW) Management Information Base (MIB)";
+  }
+  identity ilan {
+    base iana-interface-type;
+    description
+      "Internal LAN on a bridge per IEEE 802.1ap.";
+  }
+  identity pip {
+    base iana-interface-type;
+    description
+      "Provider Instance Port on a bridge per IEEE 802.1ah PBB.";
+  }
+  identity aluELP {
+    base iana-interface-type;
+    description
+      "Alcatel-Lucent Ethernet Link Protection.";
+  }
+  identity gpon {
+    base iana-interface-type;
+    description
+      "Gigabit-capable passive optical networks (G-PON) as per
+       ITU-T G.948.";
+  }
+  identity vdsl2 {
+    base iana-interface-type;
+    description
+      "Very high speed digital subscriber line Version 2
+       (as per ITU-T Recommendation G.993.2).";
+    reference
+      "RFC 5650 - Definitions of Managed Objects for Very High
+                  Speed Digital Subscriber Line 2 (VDSL2)";
+  }
+  identity capwapDot11Profile {
+    base iana-interface-type;
+    description
+      "WLAN Profile Interface.";
+    reference
+      "RFC 5834 - Control and Provisioning of Wireless Access
+                  Points (CAPWAP) Protocol Binding MIB for
+                  IEEE 802.11";
+  }
+  identity capwapDot11Bss {
+    base iana-interface-type;
+    description
+      "WLAN BSS Interface.";
+    reference
+      "RFC 5834 - Control and Provisioning of Wireless Access
+                  Points (CAPWAP) Protocol Binding MIB for
+                  IEEE 802.11";
+  }
+  identity capwapWtpVirtualRadio {
+    base iana-interface-type;
+    description
+      "WTP Virtual Radio Interface.";
+    reference
+      "RFC 5833 - Control and Provisioning of Wireless Access
+                  Points (CAPWAP) Protocol Base MIB";
+  }
+  identity bits {
+    base iana-interface-type;
+    description
+      "bitsport.";
+  }
+  identity docsCableUpstreamRfPort {
+    base iana-interface-type;
+    description
+      "DOCSIS CATV Upstream RF Port.";
+  }
+
+
+  identity cableDownstreamRfPort {
+    base iana-interface-type;
+    description
+      "CATV downstream RF Port.";
+  }
+  identity vmwareVirtualNic {
+    base iana-interface-type;
+    description
+      "VMware Virtual Network Interface.";
+  }
+  identity ieee802154 {
+    base iana-interface-type;
+    description
+      "IEEE 802.15.4 WPAN interface.";
+    reference
+      "IEEE 802.15.4-2006";
+  }
+  identity otnOdu {
+    base iana-interface-type;
+    description
+      "OTN Optical Data Unit.";
+  }
+  identity otnOtu {
+    base iana-interface-type;
+    description
+      "OTN Optical channel Transport Unit.";
+  }
+  identity ifVfiType {
+    base iana-interface-type;
+    description
+      "VPLS Forwarding Instance Interface Type.";
+  }
+  identity g9981 {
+    base iana-interface-type;
+    description
+      "G.998.1 bonded interface.";
+  }
+  identity g9982 {
+    base iana-interface-type;
+    description
+      "G.998.2 bonded interface.";
+  }
+  identity g9983 {
+    base iana-interface-type;
+    description
+      "G.998.3 bonded interface.";
+  }
+
+  identity aluEpon {
+    base iana-interface-type;
+    description
+      "Ethernet Passive Optical Networks (E-PON).";
+  }
+  identity aluEponOnu {
+    base iana-interface-type;
+    description
+      "EPON Optical Network Unit.";
+  }
+  identity aluEponPhysicalUni {
+    base iana-interface-type;
+    description
+      "EPON physical User to Network interface.";
+  }
+  identity aluEponLogicalLink {
+    base iana-interface-type;
+    description
+      "The emulation of a point-to-point link over the EPON
+       layer.";
+  }
+  identity aluGponOnu {
+    base iana-interface-type;
+    description
+      "GPON Optical Network Unit.";
+    reference
+      "ITU-T G.984.2";
+  }
+  identity aluGponPhysicalUni {
+    base iana-interface-type;
+    description
+      "GPON physical User to Network interface.";
+    reference
+      "ITU-T G.984.2";
+  }
+  identity vmwareNicTeam {
+    base iana-interface-type;
+    description
+      "VMware NIC Team.";
+  }
+}

--- a/python-inocybe-openswitch/models/ietf-inet-types.yang
+++ b/python-inocybe-openswitch/models/ietf-inet-types.yang
@@ -1,0 +1,461 @@
+module ietf-inet-types {
+
+  namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
+  prefix "inet";
+
+  organization
+   "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+   "WG Web:   <http://tools.ietf.org/wg/netmod/>
+    WG List:  <mailto:netmod@ietf.org>
+
+    WG Chair: David Kessens
+              <mailto:david.kessens@nsn.com>
+
+    WG Chair: Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>
+
+    Editor:   Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>";
+
+  description
+   "This module contains a collection of generally useful derived
+    YANG data types for Internet addresses and related things.
+
+    Copyright (c) 2013 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, is permitted pursuant to, and subject
+    to the license terms contained in, the Simplified BSD License
+    set forth in Section 4.c of the IETF Trust's Legal Provisions
+    Relating to IETF Documents
+    (http://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC 6991; see
+    the RFC itself for full legal notices.";
+
+  revision 2013-07-15 {
+    description
+     "This revision adds the following new data types:
+      - ip-address-no-zone
+      - ipv4-address-no-zone
+      - ipv6-address-no-zone";
+    reference
+     "RFC 6991: Common YANG Data Types";
+  }
+
+  revision 2010-09-24 {
+    description
+     "Initial revision.";
+    reference
+     "RFC 6021: Common YANG Data Types";
+  }
+
+  /*** collection of types related to protocol fields ***/
+
+  typedef ip-version {
+    type enumeration {
+      enum unknown {
+        value "0";
+        description
+         "An unknown or unspecified version of the Internet
+          protocol.";
+      }
+      enum ipv4 {
+        value "1";
+        description
+         "The IPv4 protocol as defined in RFC 791.";
+      }
+      enum ipv6 {
+        value "2";
+        description
+         "The IPv6 protocol as defined in RFC 2460.";
+      }
+    }
+    description
+     "This value represents the version of the IP protocol.
+
+      In the value set and its semantics, this type is equivalent
+      to the InetVersion textual convention of the SMIv2.";
+    reference
+     "RFC  791: Internet Protocol
+      RFC 2460: Internet Protocol, Version 6 (IPv6) Specification
+      RFC 4001: Textual Conventions for Internet Network Addresses";
+  }
+
+  typedef dscp {
+    type uint8 {
+      range "0..63";
+    }
+    description
+     "The dscp type represents a Differentiated Services Code Point
+      that may be used for marking packets in a traffic stream.
+      In the value set and its semantics, this type is equivalent
+      to the Dscp textual convention of the SMIv2.";
+    reference
+     "RFC 3289: Management Information Base for the Differentiated
+                Services Architecture
+      RFC 2474: Definition of the Differentiated Services Field
+                (DS Field) in the IPv4 and IPv6 Headers
+      RFC 2780: IANA Allocation Guidelines For Values In
+                the Internet Protocol and Related Headers";
+  }
+
+  typedef ipv6-flow-label {
+    type uint32 {
+      range "0..1048575";
+    }
+    description
+     "The ipv6-flow-label type represents the flow identifier or Flow
+      Label in an IPv6 packet header that may be used to
+      discriminate traffic flows.
+
+      In the value set and its semantics, this type is equivalent
+      to the IPv6FlowLabel textual convention of the SMIv2.";
+    reference
+     "RFC 3595: Textual Conventions for IPv6 Flow Label
+      RFC 2460: Internet Protocol, Version 6 (IPv6) Specification";
+  }
+
+  typedef port-number {
+    type uint16 {
+      range "0..65535";
+    }
+    description
+     "The port-number type represents a 16-bit port number of an
+      Internet transport-layer protocol such as UDP, TCP, DCCP, or
+      SCTP.  Port numbers are assigned by IANA.  A current list of
+      all assignments is available from <http://www.iana.org/>.
+
+      Note that the port number value zero is reserved by IANA.  In
+      situations where the value zero does not make sense, it can
+      be excluded by subtyping the port-number type.
+      In the value set and its semantics, this type is equivalent
+      to the InetPortNumber textual convention of the SMIv2.";
+    reference
+     "RFC  768: User Datagram Protocol
+      RFC  793: Transmission Control Protocol
+      RFC 4960: Stream Control Transmission Protocol
+      RFC 4340: Datagram Congestion Control Protocol (DCCP)
+      RFC 4001: Textual Conventions for Internet Network Addresses";
+  }
+
+  /*** collection of types related to autonomous systems ***/
+
+  typedef as-number {
+    type uint32;
+    description
+     "The as-number type represents autonomous system numbers
+      which identify an Autonomous System (AS).  An AS is a set
+      of routers under a single technical administration, using
+      an interior gateway protocol and common metrics to route
+      packets within the AS, and using an exterior gateway
+      protocol to route packets to other ASes.  IANA maintains
+      the AS number space and has delegated large parts to the
+      regional registries.
+
+      Autonomous system numbers were originally limited to 16
+      bits.  BGP extensions have enlarged the autonomous system
+      number space to 32 bits.  This type therefore uses an uint32
+      base type without a range restriction in order to support
+      a larger autonomous system number space.
+
+      In the value set and its semantics, this type is equivalent
+      to the InetAutonomousSystemNumber textual convention of
+      the SMIv2.";
+    reference
+     "RFC 1930: Guidelines for creation, selection, and registration
+                of an Autonomous System (AS)
+      RFC 4271: A Border Gateway Protocol 4 (BGP-4)
+      RFC 4001: Textual Conventions for Internet Network Addresses
+      RFC 6793: BGP Support for Four-Octet Autonomous System (AS)
+                Number Space";
+  }
+
+  /*** collection of types related to IP addresses and hostnames ***/
+
+  typedef ip-address {
+    type union {
+      type inet:ipv4-address;
+      type inet:ipv6-address;
+    }
+    description
+     "The ip-address type represents an IP address and is IP
+      version neutral.  The format of the textual representation
+      implies the IP version.  This type supports scoped addresses
+      by allowing zone identifiers in the address format.";
+    reference
+     "RFC 4007: IPv6 Scoped Address Architecture";
+  }
+
+  typedef ipv4-address {
+    type string {
+      pattern
+        '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+      +  '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'
+      + '(%[\p{N}\p{L}]+)?';
+    }
+    description
+      "The ipv4-address type represents an IPv4 address in
+       dotted-quad notation.  The IPv4 address may include a zone
+       index, separated by a % sign.
+
+       The zone index is used to disambiguate identical address
+       values.  For link-local addresses, the zone index will
+       typically be the interface index number or the name of an
+       interface.  If the zone index is not present, the default
+       zone of the device will be used.
+
+       The canonical format for the zone index is the numerical
+       format";
+  }
+
+  typedef ipv6-address {
+    type string {
+      pattern '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+            + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+            + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'
+            + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'
+            + '(%[\p{N}\p{L}]+)?';
+      pattern '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'
+            + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)'
+            + '(%.+)?';
+    }
+    description
+     "The ipv6-address type represents an IPv6 address in full,
+      mixed, shortened, and shortened-mixed notation.  The IPv6
+      address may include a zone index, separated by a % sign.
+
+      The zone index is used to disambiguate identical address
+      values.  For link-local addresses, the zone index will
+      typically be the interface index number or the name of an
+      interface.  If the zone index is not present, the default
+      zone of the device will be used.
+
+
+
+      The canonical format of IPv6 addresses uses the textual
+      representation defined in Section 4 of RFC 5952.  The
+      canonical format for the zone index is the numerical
+      format as described in Section 11.2 of RFC 4007.";
+    reference
+     "RFC 4291: IP Version 6 Addressing Architecture
+      RFC 4007: IPv6 Scoped Address Architecture
+      RFC 5952: A Recommendation for IPv6 Address Text
+                Representation";
+  }
+
+  typedef ip-address-no-zone {
+    type union {
+      type inet:ipv4-address-no-zone;
+      type inet:ipv6-address-no-zone;
+    }
+    description
+     "The ip-address-no-zone type represents an IP address and is
+      IP version neutral.  The format of the textual representation
+      implies the IP version.  This type does not support scoped
+      addresses since it does not allow zone identifiers in the
+      address format.";
+    reference
+     "RFC 4007: IPv6 Scoped Address Architecture";
+  }
+
+  typedef ipv4-address-no-zone {
+    type inet:ipv4-address {
+      pattern '[0-9\.]*';
+    }
+    description
+      "An IPv4 address without a zone index.  This type, derived from
+       ipv4-address, may be used in situations where the zone is
+       known from the context and hence no zone index is needed.";
+  }
+
+  typedef ipv6-address-no-zone {
+    type inet:ipv6-address {
+      pattern '[0-9a-fA-F:\.]*';
+    }
+    description
+      "An IPv6 address without a zone index.  This type, derived from
+       ipv6-address, may be used in situations where the zone is
+       known from the context and hence no zone index is needed.";
+    reference
+     "RFC 4291: IP Version 6 Addressing Architecture
+      RFC 4007: IPv6 Scoped Address Architecture
+      RFC 5952: A Recommendation for IPv6 Address Text
+                Representation";
+  }
+
+  typedef ip-prefix {
+    type union {
+      type inet:ipv4-prefix;
+      type inet:ipv6-prefix;
+    }
+    description
+     "The ip-prefix type represents an IP prefix and is IP
+      version neutral.  The format of the textual representations
+      implies the IP version.";
+  }
+
+  typedef ipv4-prefix {
+    type string {
+      pattern
+         '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+       +  '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'
+       + '/(([0-9])|([1-2][0-9])|(3[0-2]))';
+    }
+    description
+     "The ipv4-prefix type represents an IPv4 address prefix.
+      The prefix length is given by the number following the
+      slash character and must be less than or equal to 32.
+
+      A prefix length value of n corresponds to an IP address
+      mask that has n contiguous 1-bits from the most
+      significant bit (MSB) and all other bits set to 0.
+
+      The canonical format of an IPv4 prefix has all bits of
+      the IPv4 address set to zero that are not part of the
+      IPv4 prefix.";
+  }
+
+  typedef ipv6-prefix {
+    type string {
+      pattern '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+            + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+            + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'
+            + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'
+            + '(/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))';
+      pattern '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'
+            + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)'
+            + '(/.+)';
+    }
+
+
+    description
+     "The ipv6-prefix type represents an IPv6 address prefix.
+      The prefix length is given by the number following the
+      slash character and must be less than or equal to 128.
+
+      A prefix length value of n corresponds to an IP address
+      mask that has n contiguous 1-bits from the most
+      significant bit (MSB) and all other bits set to 0.
+
+      The IPv6 address should have all bits that do not belong
+      to the prefix set to zero.
+
+      The canonical format of an IPv6 prefix has all bits of
+      the IPv6 address set to zero that are not part of the
+      IPv6 prefix.  Furthermore, the IPv6 address is represented
+      as defined in Section 4 of RFC 5952.";
+    reference
+     "RFC 5952: A Recommendation for IPv6 Address Text
+                Representation";
+  }
+
+  /*** collection of domain name and URI types ***/
+
+  typedef domain-name {
+    type string {
+      pattern
+        '((([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.)*'
+      + '([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.?)'
+      + '|\.';
+      length "1..253";
+    }
+    description
+     "The domain-name type represents a DNS domain name.  The
+      name SHOULD be fully qualified whenever possible.
+
+      Internet domain names are only loosely specified.  Section
+      3.5 of RFC 1034 recommends a syntax (modified in Section
+      2.1 of RFC 1123).  The pattern above is intended to allow
+      for current practice in domain name use, and some possible
+      future expansion.  It is designed to hold various types of
+      domain names, including names used for A or AAAA records
+      (host names) and other records, such as SRV records.  Note
+      that Internet host names have a stricter syntax (described
+      in RFC 952) than the DNS recommendations in RFCs 1034 and
+      1123, and that systems that want to store host names in
+      schema nodes using the domain-name type are recommended to
+      adhere to this stricter standard to ensure interoperability.
+
+      The encoding of DNS names in the DNS protocol is limited
+      to 255 characters.  Since the encoding consists of labels
+      prefixed by a length bytes and there is a trailing NULL
+      byte, only 253 characters can appear in the textual dotted
+      notation.
+
+      The description clause of schema nodes using the domain-name
+      type MUST describe when and how these names are resolved to
+      IP addresses.  Note that the resolution of a domain-name value
+      may require to query multiple DNS records (e.g., A for IPv4
+      and AAAA for IPv6).  The order of the resolution process and
+      which DNS record takes precedence can either be defined
+      explicitly or may depend on the configuration of the
+      resolver.
+
+      Domain-name values use the US-ASCII encoding.  Their canonical
+      format uses lowercase US-ASCII characters.  Internationalized
+      domain names MUST be A-labels as per RFC 5890.";
+    reference
+     "RFC  952: DoD Internet Host Table Specification
+      RFC 1034: Domain Names - Concepts and Facilities
+      RFC 1123: Requirements for Internet Hosts -- Application
+                and Support
+      RFC 2782: A DNS RR for specifying the location of services
+                (DNS SRV)
+      RFC 5890: Internationalized Domain Names in Applications
+                (IDNA): Definitions and Document Framework";
+  }
+
+  typedef host {
+    type union {
+      type inet:ip-address;
+      type inet:domain-name;
+    }
+    description
+     "The host type represents either an IP address or a DNS
+      domain name.";
+  }
+
+  typedef uri {
+    type string;
+    description
+     "The uri type represents a Uniform Resource Identifier
+      (URI) as defined by STD 66.
+
+      Objects using the uri type MUST be in US-ASCII encoding,
+      and MUST be normalized as described by RFC 3986 Sections
+      6.2.1, 6.2.2.1, and 6.2.2.2.  All unnecessary
+      percent-encoding is removed, and all case-insensitive
+      characters are set to lowercase except for hexadecimal
+      digits, which are normalized to uppercase as described in
+      Section 6.2.2.1.
+
+      The purpose of this normalization is to help provide
+      unique URIs.  Note that this normalization is not
+      sufficient to provide uniqueness.  Two URIs that are
+      textually distinct after this normalization may still be
+      equivalent.
+
+      Objects using the uri type may restrict the schemes that
+      they permit.  For example, 'data:' and 'urn:' schemes
+      might not be appropriate.
+
+      A zero-length URI is not a valid URI.  This can be used to
+      express 'URI absent' where required.
+
+      In the value set and its semantics, this type is equivalent
+      to the Uri SMIv2 textual convention defined in RFC 5017.";
+    reference
+     "RFC 3986: Uniform Resource Identifier (URI): Generic Syntax
+      RFC 3305: Report from the Joint W3C/IETF URI Planning Interest
+                Group: Uniform Resource Identifiers (URIs), URLs,
+                and Uniform Resource Names (URNs): Clarifications
+                and Recommendations
+      RFC 5017: MIB Textual Conventions for Uniform Resource
+                Identifiers (URIs)";
+  }
+
+}

--- a/python-inocybe-openswitch/models/ietf-interfaces.yang
+++ b/python-inocybe-openswitch/models/ietf-interfaces.yang
@@ -1,0 +1,725 @@
+module ietf-interfaces {
+
+  namespace "urn:ietf:params:xml:ns:yang:ietf-interfaces";
+  prefix if;
+
+  import ietf-yang-types {
+    prefix yang;
+  }
+
+  organization
+    "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+    "WG Web:   <http://tools.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+
+     WG Chair: Thomas Nadeau
+               <mailto:tnadeau@lucidvision.com>
+
+     WG Chair: Juergen Schoenwaelder
+               <mailto:j.schoenwaelder@jacobs-university.de>
+
+     Editor:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>";
+
+  description
+    "This module contains a collection of YANG definitions for
+     managing network interfaces.
+
+     Copyright (c) 2014 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 7223; see
+     the RFC itself for full legal notices.";
+
+  revision 2014-05-08 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 7223: A YANG Data Model for Interface Management";
+  }
+
+  /*
+   * Typedefs
+   */
+
+  typedef interface-ref {
+    type leafref {
+      path "/if:interfaces/if:interface/if:name";
+    }
+    description
+      "This type is used by data models that need to reference
+       configured interfaces.";
+  }
+
+  typedef interface-state-ref {
+    type leafref {
+      path "/if:interfaces-state/if:interface/if:name";
+    }
+    description
+      "This type is used by data models that need to reference
+       the operationally present interfaces.";
+  }
+
+  /*
+   * Identities
+   */
+
+  identity interface-type {
+    description
+      "Base identity from which specific interface types are
+       derived.";
+  }
+
+  /*
+   * Features
+   */
+
+  feature arbitrary-names {
+    description
+      "This feature indicates that the device allows user-controlled
+       interfaces to be named arbitrarily.";
+  }
+  feature pre-provisioning {
+    description
+      "This feature indicates that the device supports
+       pre-provisioning of interface configuration, i.e., it is
+       possible to configure an interface whose physical interface
+       hardware is not present on the device.";
+  }
+
+  feature if-mib {
+    description
+      "This feature indicates that the device implements
+       the IF-MIB.";
+    reference
+      "RFC 2863: The Interfaces Group MIB";
+  }
+
+  /*
+   * Configuration data nodes
+   */
+
+  container interfaces {
+    description
+      "Interface configuration parameters.";
+
+    list interface {
+      key "name";
+
+      description
+        "The list of configured interfaces on the device.
+
+         The operational state of an interface is available in the
+         /interfaces-state/interface list.  If the configuration of a
+         system-controlled interface cannot be used by the system
+         (e.g., the interface hardware present does not match the
+         interface type), then the configuration is not applied to
+         the system-controlled interface shown in the
+         /interfaces-state/interface list.  If the configuration
+         of a user-controlled interface cannot be used by the system,
+         the configured interface is not instantiated in the
+         /interfaces-state/interface list.";
+
+     leaf name {
+        type string;
+        description
+          "The name of the interface.
+
+           A device MAY restrict the allowed values for this leaf,
+           possibly depending on the type of the interface.
+           For system-controlled interfaces, this leaf is the
+           device-specific name of the interface.  The 'config false'
+           list /interfaces-state/interface contains the currently
+           existing interfaces on the device.
+
+           If a client tries to create configuration for a
+           system-controlled interface that is not present in the
+           /interfaces-state/interface list, the server MAY reject
+           the request if the implementation does not support
+           pre-provisioning of interfaces or if the name refers to
+           an interface that can never exist in the system.  A
+           NETCONF server MUST reply with an rpc-error with the
+           error-tag 'invalid-value' in this case.
+
+           If the device supports pre-provisioning of interface
+           configuration, the 'pre-provisioning' feature is
+           advertised.
+
+           If the device allows arbitrarily named user-controlled
+           interfaces, the 'arbitrary-names' feature is advertised.
+
+           When a configured user-controlled interface is created by
+           the system, it is instantiated with the same name in the
+           /interface-state/interface list.";
+      }
+
+      leaf description {
+        type string;
+        description
+          "A textual description of the interface.
+
+           A server implementation MAY map this leaf to the ifAlias
+           MIB object.  Such an implementation needs to use some
+           mechanism to handle the differences in size and characters
+           allowed between this leaf and ifAlias.  The definition of
+           such a mechanism is outside the scope of this document.
+
+           Since ifAlias is defined to be stored in non-volatile
+           storage, the MIB implementation MUST map ifAlias to the
+           value of 'description' in the persistently stored
+           datastore.
+
+           Specifically, if the device supports ':startup', when
+           ifAlias is read the device MUST return the value of
+           'description' in the 'startup' datastore, and when it is
+           written, it MUST be written to the 'running' and 'startup'
+           datastores.  Note that it is up to the implementation to
+
+           decide whether to modify this single leaf in 'startup' or
+           perform an implicit copy-config from 'running' to
+           'startup'.
+
+           If the device does not support ':startup', ifAlias MUST
+           be mapped to the 'description' leaf in the 'running'
+           datastore.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAlias";
+      }
+
+      leaf type {
+        type identityref {
+          base interface-type;
+        }
+        mandatory true;
+        description
+          "The type of the interface.
+
+           When an interface entry is created, a server MAY
+           initialize the type leaf with a valid value, e.g., if it
+           is possible to derive the type from the name of the
+           interface.
+
+           If a client tries to set the type of an interface to a
+           value that can never be used by the system, e.g., if the
+           type is not supported or if the type does not match the
+           name of the interface, the server MUST reject the request.
+           A NETCONF server MUST reply with an rpc-error with the
+           error-tag 'invalid-value' in this case.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifType";
+      }
+
+      leaf enabled {
+        type boolean;
+        default "true";
+        description
+          "This leaf contains the configured, desired state of the
+           interface.
+
+           Systems that implement the IF-MIB use the value of this
+           leaf in the 'running' datastore to set
+           IF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry
+           has been initialized, as described in RFC 2863.
+
+
+
+           Changes in this leaf in the 'running' datastore are
+           reflected in ifAdminStatus, but if ifAdminStatus is
+           changed over SNMP, this leaf is not affected.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+      }
+
+      leaf link-up-down-trap-enable {
+        if-feature if-mib;
+        type enumeration {
+          enum enabled {
+            value 1;
+          }
+          enum disabled {
+            value 2;
+          }
+        }
+        description
+          "Controls whether linkUp/linkDown SNMP notifications
+           should be generated for this interface.
+
+           If this node is not configured, the value 'enabled' is
+           operationally used by the server for interfaces that do
+           not operate on top of any other interface (i.e., there are
+           no 'lower-layer-if' entries), and 'disabled' otherwise.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifLinkUpDownTrapEnable";
+      }
+    }
+  }
+
+  /*
+   * Operational state data nodes
+   */
+
+  container interfaces-state {
+    config false;
+    description
+      "Data nodes for the operational state of interfaces.";
+
+    list interface {
+      key "name";
+
+
+
+
+
+      description
+        "The list of interfaces on the device.
+
+         System-controlled interfaces created by the system are
+         always present in this list, whether they are configured or
+         not.";
+
+      leaf name {
+        type string;
+        description
+          "The name of the interface.
+
+           A server implementation MAY map this leaf to the ifName
+           MIB object.  Such an implementation needs to use some
+           mechanism to handle the differences in size and characters
+           allowed between this leaf and ifName.  The definition of
+           such a mechanism is outside the scope of this document.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifName";
+      }
+
+      leaf type {
+        type identityref {
+          base interface-type;
+        }
+        mandatory true;
+        description
+          "The type of the interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifType";
+      }
+
+      leaf admin-status {
+        if-feature if-mib;
+        type enumeration {
+          enum up {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum down {
+            value 2;
+            description
+              "Not ready to pass packets and not in some test mode.";
+          }
+
+
+
+          enum testing {
+            value 3;
+            description
+              "In some test mode.";
+          }
+        }
+        mandatory true;
+        description
+          "The desired state of the interface.
+
+           This leaf has the same read semantics as ifAdminStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+      }
+
+      leaf oper-status {
+        type enumeration {
+          enum up {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum down {
+            value 2;
+            description
+              "The interface does not pass any packets.";
+          }
+          enum testing {
+            value 3;
+            description
+              "In some test mode.  No operational packets can
+               be passed.";
+          }
+          enum unknown {
+            value 4;
+            description
+              "Status cannot be determined for some reason.";
+          }
+          enum dormant {
+            value 5;
+            description
+              "Waiting for some external event.";
+          }
+          enum not-present {
+            value 6;
+            description
+              "Some component (typically hardware) is missing.";
+          }
+          enum lower-layer-down {
+            value 7;
+            description
+              "Down due to state of lower-layer interface(s).";
+          }
+        }
+        mandatory true;
+        description
+          "The current operational state of the interface.
+
+           This leaf has the same semantics as ifOperStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifOperStatus";
+      }
+
+      leaf last-change {
+        type yang:date-and-time;
+        description
+          "The time the interface entered its current operational
+           state.  If the current state was entered prior to the
+           last re-initialization of the local network management
+           subsystem, then this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifLastChange";
+      }
+
+      leaf if-index {
+        if-feature if-mib;
+        type int32 {
+          range "1..2147483647";
+        }
+        mandatory true;
+        description
+          "The ifIndex value for the ifEntry represented by this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifIndex";
+      }
+
+      leaf phys-address {
+        type yang:phys-address;
+        description
+          "The interface's address at its protocol sub-layer.  For
+           example, for an 802.x interface, this object normally
+           contains a Media Access Control (MAC) address.  The
+           interface's media-specific modules must define the bit
+
+
+           and byte ordering and the format of the value of this
+           object.  For interfaces that do not have such an address
+           (e.g., a serial line), this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifPhysAddress";
+      }
+
+      leaf-list higher-layer-if {
+        type interface-state-ref;
+        description
+          "A list of references to interfaces layered on top of this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+
+      leaf-list lower-layer-if {
+        type interface-state-ref;
+        description
+          "A list of references to interfaces layered underneath this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+
+      leaf speed {
+        type yang:gauge64;
+        units "bits/second";
+        description
+            "An estimate of the interface's current bandwidth in bits
+             per second.  For interfaces that do not vary in
+             bandwidth or for those where no accurate estimation can
+             be made, this node should contain the nominal bandwidth.
+             For interfaces that have no concept of bandwidth, this
+             node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifSpeed, ifHighSpeed";
+      }
+
+
+
+
+
+
+
+
+
+      container statistics {
+        description
+          "A collection of interface-related statistics objects.";
+
+        leaf discontinuity-time {
+          type yang:date-and-time;
+          mandatory true;
+          description
+            "The time on the most recent occasion at which any one or
+             more of this interface's counters suffered a
+             discontinuity.  If no such discontinuities have occurred
+             since the last re-initialization of the local management
+             subsystem, then this node contains the time the local
+             management subsystem re-initialized itself.";
+        }
+
+        leaf in-octets {
+          type yang:counter64;
+          description
+            "The total number of octets received on the interface,
+             including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInOctets";
+        }
+
+        leaf in-unicast-pkts {
+          type yang:counter64;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were not addressed to a
+             multicast or broadcast address at this sub-layer.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInUcastPkts";
+        }
+
+
+
+
+        leaf in-broadcast-pkts {
+          type yang:counter64;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a broadcast
+             address at this sub-layer.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInBroadcastPkts";
+        }
+
+        leaf in-multicast-pkts {
+          type yang:counter64;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a multicast
+             address at this sub-layer.  For a MAC-layer protocol,
+             this includes both Group and Functional addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInMulticastPkts";
+        }
+
+        leaf in-discards {
+          type yang:counter32;
+          description
+            "The number of inbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being deliverable to a higher-layer
+             protocol.  One possible reason for discarding such a
+             packet could be to free up buffer space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+
+
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInDiscards";
+        }
+
+        leaf in-errors {
+          type yang:counter32;
+          description
+            "For packet-oriented interfaces, the number of inbound
+             packets that contained errors preventing them from being
+             deliverable to a higher-layer protocol.  For character-
+             oriented or fixed-length interfaces, the number of
+             inbound transmission units that contained errors
+             preventing them from being deliverable to a higher-layer
+             protocol.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInErrors";
+        }
+
+        leaf in-unknown-protos {
+          type yang:counter32;
+          description
+            "For packet-oriented interfaces, the number of packets
+             received via the interface that were discarded because
+             of an unknown or unsupported protocol.  For
+             character-oriented or fixed-length interfaces that
+             support protocol multiplexing, the number of
+             transmission units received via the interface that were
+             discarded because of an unknown or unsupported protocol.
+             For any interface that does not support protocol
+             multiplexing, this counter is not present.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInUnknownProtos";
+        }
+
+
+
+
+
+        leaf out-octets {
+          type yang:counter64;
+          description
+            "The total number of octets transmitted out of the
+             interface, including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutOctets";
+        }
+
+        leaf out-unicast-pkts {
+          type yang:counter64;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted, and that were not addressed
+             to a multicast or broadcast address at this sub-layer,
+             including those that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutUcastPkts";
+        }
+
+        leaf out-broadcast-pkts {
+          type yang:counter64;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted, and that were addressed to a
+             broadcast address at this sub-layer, including those
+             that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutBroadcastPkts";
+        }
+
+
+        leaf out-multicast-pkts {
+          type yang:counter64;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted, and that were addressed to a
+             multicast address at this sub-layer, including those
+             that were discarded or not sent.  For a MAC-layer
+             protocol, this includes both Group and Functional
+             addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutMulticastPkts";
+        }
+
+        leaf out-discards {
+          type yang:counter32;
+          description
+            "The number of outbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being transmitted.  One possible reason
+             for discarding such a packet could be to free up buffer
+             space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutDiscards";
+        }
+
+        leaf out-errors {
+          type yang:counter32;
+          description
+            "For packet-oriented interfaces, the number of outbound
+             packets that could not be transmitted because of errors.
+             For character-oriented or fixed-length interfaces, the
+             number of outbound transmission units that could not be
+             transmitted because of errors.
+
+
+
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutErrors";
+        }
+      }
+    }
+  }
+}

--- a/python-inocybe-openswitch/models/ietf-yang-types.yang
+++ b/python-inocybe-openswitch/models/ietf-yang-types.yang
@@ -1,0 +1,480 @@
+module ietf-yang-types {
+
+  namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
+  prefix "yang";
+
+  organization
+   "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+   "WG Web:   <http://tools.ietf.org/wg/netmod/>
+    WG List:  <mailto:netmod@ietf.org>
+
+    WG Chair: David Kessens
+              <mailto:david.kessens@nsn.com>
+
+    WG Chair: Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>
+
+    Editor:   Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>";
+
+  description
+   "This module contains a collection of generally useful derived
+    YANG data types.
+
+    Copyright (c) 2013 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, is permitted pursuant to, and subject
+    to the license terms contained in, the Simplified BSD License
+    set forth in Section 4.c of the IETF Trust's Legal Provisions
+    Relating to IETF Documents
+    (http://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC 6991; see
+    the RFC itself for full legal notices.";
+
+  revision 2013-07-15 {
+    description
+     "This revision adds the following new data types:
+      - yang-identifier
+      - hex-string
+      - uuid
+      - dotted-quad";
+    reference
+     "RFC 6991: Common YANG Data Types";
+  }
+
+  revision 2010-09-24 {
+    description
+     "Initial revision.";
+    reference
+     "RFC 6021: Common YANG Data Types";
+  }
+
+  /*** collection of counter and gauge types ***/
+
+  typedef counter32 {
+    type uint32;
+    description
+     "The counter32 type represents a non-negative integer
+      that monotonically increases until it reaches a
+      maximum value of 2^32-1 (4294967295 decimal), when it
+      wraps around and starts increasing again from zero.
+
+      Counters have no defined 'initial' value, and thus, a
+      single value of a counter has (in general) no information
+      content.  Discontinuities in the monotonically increasing
+      value normally occur at re-initialization of the
+      management system, and at other times as specified in the
+      description of a schema node using this type.  If such
+      other times can occur, for example, the creation of
+      a schema node of type counter32 at times other than
+      re-initialization, then a corresponding schema node
+      should be defined, with an appropriate type, to indicate
+      the last discontinuity.
+
+      The counter32 type should not be used for configuration
+      schema nodes.  A default statement SHOULD NOT be used in
+      combination with the type counter32.
+
+      In the value set and its semantics, this type is equivalent
+      to the Counter32 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef zero-based-counter32 {
+    type yang:counter32;
+    default "0";
+    description
+     "The zero-based-counter32 type represents a counter32
+      that has the defined 'initial' value zero.
+
+      A schema node of this type will be set to zero (0) on creation
+      and will thereafter increase monotonically until it reaches
+      a maximum value of 2^32-1 (4294967295 decimal), when it
+      wraps around and starts increasing again from zero.
+
+      Provided that an application discovers a new schema node
+      of this type within the minimum time to wrap, it can use the
+      'initial' value as a delta.  It is important for a management
+      station to be aware of this minimum time and the actual time
+      between polls, and to discard data if the actual time is too
+      long or there is no defined minimum time.
+
+      In the value set and its semantics, this type is equivalent
+      to the ZeroBasedCounter32 textual convention of the SMIv2.";
+    reference
+      "RFC 4502: Remote Network Monitoring Management Information
+                 Base Version 2";
+  }
+
+  typedef counter64 {
+    type uint64;
+    description
+     "The counter64 type represents a non-negative integer
+      that monotonically increases until it reaches a
+      maximum value of 2^64-1 (18446744073709551615 decimal),
+      when it wraps around and starts increasing again from zero.
+
+      Counters have no defined 'initial' value, and thus, a
+      single value of a counter has (in general) no information
+      content.  Discontinuities in the monotonically increasing
+      value normally occur at re-initialization of the
+      management system, and at other times as specified in the
+      description of a schema node using this type.  If such
+      other times can occur, for example, the creation of
+      a schema node of type counter64 at times other than
+      re-initialization, then a corresponding schema node
+      should be defined, with an appropriate type, to indicate
+      the last discontinuity.
+
+      The counter64 type should not be used for configuration
+      schema nodes.  A default statement SHOULD NOT be used in
+      combination with the type counter64.
+
+      In the value set and its semantics, this type is equivalent
+      to the Counter64 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef zero-based-counter64 {
+    type yang:counter64;
+    default "0";
+    description
+     "The zero-based-counter64 type represents a counter64 that
+      has the defined 'initial' value zero.
+
+
+
+
+      A schema node of this type will be set to zero (0) on creation
+      and will thereafter increase monotonically until it reaches
+      a maximum value of 2^64-1 (18446744073709551615 decimal),
+      when it wraps around and starts increasing again from zero.
+
+      Provided that an application discovers a new schema node
+      of this type within the minimum time to wrap, it can use the
+      'initial' value as a delta.  It is important for a management
+      station to be aware of this minimum time and the actual time
+      between polls, and to discard data if the actual time is too
+      long or there is no defined minimum time.
+
+      In the value set and its semantics, this type is equivalent
+      to the ZeroBasedCounter64 textual convention of the SMIv2.";
+    reference
+     "RFC 2856: Textual Conventions for Additional High Capacity
+                Data Types";
+  }
+
+  typedef gauge32 {
+    type uint32;
+    description
+     "The gauge32 type represents a non-negative integer, which
+      may increase or decrease, but shall never exceed a maximum
+      value, nor fall below a minimum value.  The maximum value
+      cannot be greater than 2^32-1 (4294967295 decimal), and
+      the minimum value cannot be smaller than 0.  The value of
+      a gauge32 has its maximum value whenever the information
+      being modeled is greater than or equal to its maximum
+      value, and has its minimum value whenever the information
+      being modeled is smaller than or equal to its minimum value.
+      If the information being modeled subsequently decreases
+      below (increases above) the maximum (minimum) value, the
+      gauge32 also decreases (increases).
+
+      In the value set and its semantics, this type is equivalent
+      to the Gauge32 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef gauge64 {
+    type uint64;
+    description
+     "The gauge64 type represents a non-negative integer, which
+      may increase or decrease, but shall never exceed a maximum
+      value, nor fall below a minimum value.  The maximum value
+      cannot be greater than 2^64-1 (18446744073709551615), and
+      the minimum value cannot be smaller than 0.  The value of
+      a gauge64 has its maximum value whenever the information
+      being modeled is greater than or equal to its maximum
+      value, and has its minimum value whenever the information
+      being modeled is smaller than or equal to its minimum value.
+      If the information being modeled subsequently decreases
+      below (increases above) the maximum (minimum) value, the
+      gauge64 also decreases (increases).
+
+      In the value set and its semantics, this type is equivalent
+      to the CounterBasedGauge64 SMIv2 textual convention defined
+      in RFC 2856";
+    reference
+     "RFC 2856: Textual Conventions for Additional High Capacity
+                Data Types";
+  }
+
+  /*** collection of identifier-related types ***/
+
+  typedef object-identifier {
+    type string {
+      pattern '(([0-1](\.[1-3]?[0-9]))|(2\.(0|([1-9]\d*))))'
+            + '(\.(0|([1-9]\d*)))*';
+    }
+    description
+     "The object-identifier type represents administratively
+      assigned names in a registration-hierarchical-name tree.
+
+      Values of this type are denoted as a sequence of numerical
+      non-negative sub-identifier values.  Each sub-identifier
+      value MUST NOT exceed 2^32-1 (4294967295).  Sub-identifiers
+      are separated by single dots and without any intermediate
+      whitespace.
+
+      The ASN.1 standard restricts the value space of the first
+      sub-identifier to 0, 1, or 2.  Furthermore, the value space
+      of the second sub-identifier is restricted to the range
+      0 to 39 if the first sub-identifier is 0 or 1.  Finally,
+      the ASN.1 standard requires that an object identifier
+      has always at least two sub-identifiers.  The pattern
+      captures these restrictions.
+
+      Although the number of sub-identifiers is not limited,
+      module designers should realize that there may be
+      implementations that stick with the SMIv2 limit of 128
+      sub-identifiers.
+
+      This type is a superset of the SMIv2 OBJECT IDENTIFIER type
+      since it is not restricted to 128 sub-identifiers.  Hence,
+      this type SHOULD NOT be used to represent the SMIv2 OBJECT
+      IDENTIFIER type; the object-identifier-128 type SHOULD be
+      used instead.";
+    reference
+     "ISO9834-1: Information technology -- Open Systems
+      Interconnection -- Procedures for the operation of OSI
+      Registration Authorities: General procedures and top
+      arcs of the ASN.1 Object Identifier tree";
+  }
+
+  typedef object-identifier-128 {
+    type object-identifier {
+      pattern '\d*(\.\d*){1,127}';
+    }
+    description
+     "This type represents object-identifiers restricted to 128
+      sub-identifiers.
+
+      In the value set and its semantics, this type is equivalent
+      to the OBJECT IDENTIFIER type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef yang-identifier {
+    type string {
+      length "1..max";
+      pattern '[a-zA-Z_][a-zA-Z0-9\-_.]*';
+      pattern '.|..|[^xX].*|.[^mM].*|..[^lL].*';
+    }
+    description
+      "A YANG identifier string as defined by the 'identifier'
+       rule in Section 12 of RFC 6020.  An identifier must
+       start with an alphabetic character or an underscore
+       followed by an arbitrary sequence of alphabetic or
+       numeric characters, underscores, hyphens, or dots.
+
+       A YANG identifier MUST NOT start with any possible
+       combination of the lowercase or uppercase character
+       sequence 'xml'.";
+    reference
+      "RFC 6020: YANG - A Data Modeling Language for the Network
+                 Configuration Protocol (NETCONF)";
+  }
+
+  /*** collection of types related to date and time***/
+
+  typedef date-and-time {
+    type string {
+      pattern '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?'
+            + '(Z|[\+\-]\d{2}:\d{2})';
+    }
+    description
+     "The date-and-time type is a profile of the ISO 8601
+      standard for representation of dates and times using the
+      Gregorian calendar.  The profile is defined by the
+      date-time production in Section 5.6 of RFC 3339.
+
+      The date-and-time type is compatible with the dateTime XML
+      schema type with the following notable exceptions:
+
+      (a) The date-and-time type does not allow negative years.
+
+      (b) The date-and-time time-offset -00:00 indicates an unknown
+          time zone (see RFC 3339) while -00:00 and +00:00 and Z
+          all represent the same time zone in dateTime.
+
+      (c) The canonical format (see below) of data-and-time values
+          differs from the canonical format used by the dateTime XML
+          schema type, which requires all times to be in UTC using
+          the time-offset 'Z'.
+
+      This type is not equivalent to the DateAndTime textual
+      convention of the SMIv2 since RFC 3339 uses a different
+      separator between full-date and full-time and provides
+      higher resolution of time-secfrac.
+
+      The canonical format for date-and-time values with a known time
+      zone uses a numeric time zone offset that is calculated using
+      the device's configured known offset to UTC time.  A change of
+      the device's offset to UTC time will cause date-and-time values
+      to change accordingly.  Such changes might happen periodically
+      in case a server follows automatically daylight saving time
+      (DST) time zone offset changes.  The canonical format for
+      date-and-time values with an unknown time zone (usually
+      referring to the notion of local time) uses the time-offset
+      -00:00.";
+    reference
+     "RFC 3339: Date and Time on the Internet: Timestamps
+      RFC 2579: Textual Conventions for SMIv2
+      XSD-TYPES: XML Schema Part 2: Datatypes Second Edition";
+  }
+
+  typedef timeticks {
+    type uint32;
+    description
+     "The timeticks type represents a non-negative integer that
+      represents the time, modulo 2^32 (4294967296 decimal), in
+      hundredths of a second between two epochs.  When a schema
+      node is defined that uses this type, the description of
+      the schema node identifies both of the reference epochs.
+
+      In the value set and its semantics, this type is equivalent
+      to the TimeTicks type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef timestamp {
+    type yang:timeticks;
+    description
+     "The timestamp type represents the value of an associated
+      timeticks schema node at which a specific occurrence
+      happened.  The specific occurrence must be defined in the
+      description of any schema node defined using this type.  When
+      the specific occurrence occurred prior to the last time the
+      associated timeticks attribute was zero, then the timestamp
+      value is zero.  Note that this requires all timestamp values
+      to be reset to zero when the value of the associated timeticks
+      attribute reaches 497+ days and wraps around to zero.
+
+      The associated timeticks schema node must be specified
+      in the description of any schema node using this type.
+
+      In the value set and its semantics, this type is equivalent
+      to the TimeStamp textual convention of the SMIv2.";
+    reference
+     "RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  /*** collection of generic address types ***/
+
+  typedef phys-address {
+    type string {
+      pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+    }
+
+
+
+
+    description
+     "Represents media- or physical-level addresses represented
+      as a sequence octets, each octet represented by two hexadecimal
+      numbers.  Octets are separated by colons.  The canonical
+      representation uses lowercase characters.
+
+      In the value set and its semantics, this type is equivalent
+      to the PhysAddress textual convention of the SMIv2.";
+    reference
+     "RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  typedef mac-address {
+    type string {
+      pattern '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}';
+    }
+    description
+     "The mac-address type represents an IEEE 802 MAC address.
+      The canonical representation uses lowercase characters.
+
+      In the value set and its semantics, this type is equivalent
+      to the MacAddress textual convention of the SMIv2.";
+    reference
+     "IEEE 802: IEEE Standard for Local and Metropolitan Area
+                Networks: Overview and Architecture
+      RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  /*** collection of XML-specific types ***/
+
+  typedef xpath1.0 {
+    type string;
+    description
+     "This type represents an XPATH 1.0 expression.
+
+      When a schema node is defined that uses this type, the
+      description of the schema node MUST specify the XPath
+      context in which the XPath expression is evaluated.";
+    reference
+     "XPATH: XML Path Language (XPath) Version 1.0";
+  }
+
+  /*** collection of string types ***/
+
+  typedef hex-string {
+    type string {
+      pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+    }
+    description
+     "A hexadecimal string with octets represented as hex digits
+      separated by colons.  The canonical representation uses
+      lowercase characters.";
+  }
+
+  typedef uuid {
+    type string {
+      pattern '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-'
+            + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+    }
+    description
+     "A Universally Unique IDentifier in the string representation
+      defined in RFC 4122.  The canonical representation uses
+      lowercase characters.
+
+      The following is an example of a UUID in string representation:
+      f81d4fae-7dec-11d0-a765-00a0c91e6bf6
+      ";
+    reference
+     "RFC 4122: A Universally Unique IDentifier (UUID) URN
+                Namespace";
+  }
+
+  typedef dotted-quad {
+    type string {
+      pattern
+        '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+      + '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])';
+    }
+    description
+      "An unsigned 32-bit number expressed in the dotted-quad
+       notation, i.e., four octets written as decimal numbers
+       and separated with the '.' (full stop) character.";
+  }
+}

--- a/python-inocybe-tree/inocybe_tree/jsonrpc.py
+++ b/python-inocybe-tree/inocybe_tree/jsonrpc.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+'''Method interfaces and implementations for `JSON-RPC 2.0`_ data tree services.
+
+   .. _JSON-RPC 2.0: http://www.jsonrpc.org/specification
+'''
+
+class DataRead(object):
+    '''A method interface for implementing YANG RPCs for reading data specified in OpenDaylight
+       YANG module `opendaylight-jsonrpc-data`.
+    '''
+    def __init__(self):
+        self.methods.update({ ### pylint: disable=no-member
+            'exists': self.exists,
+            'read': self.read,
+        })
+    def exists(self, store, entity, path):
+        '''Method definition for opendaylight-jsonrpc-data RPC `exists`.'''
+        raise NotImplementedError()
+    def read(self, store, entity, path):
+        '''Method definition for opendaylight-jsonrpc-data RPC `read`.'''
+        raise NotImplementedError()
+
+class DataWrite(object):
+    '''A method interface for implementing YANG RPCs for writing data specified in OpenDaylight
+       YANG module `opendaylight-jsonrpc-data`.
+    '''
+    def __init__(self):
+        self.methods.update({ ### pylint: disable=no-member
+            'txid': self.txid,
+            'put': self.put,
+            'merge': self.merge,
+            'delete': self.delete,
+            'commit': self.commit,
+            'cancel': self.cancel,
+            'error': self.error,
+        })
+    def txid(self):
+        '''Method definition for opendaylight-jsonrpc-data RPC `txid`.'''
+        raise NotImplementedError()
+    def put(self, txid, store, entity, path, data): ### pylint: disable=too-many-arguments
+        '''Method definition for opendaylight-jsonrpc-data RPC `put`.'''
+        raise NotImplementedError()
+    def merge(self, txid, store, entity, path, data): ### pylint: disable=too-many-arguments
+        '''Method definition for opendaylight-jsonrpc-data RPC `merge`.'''
+        raise NotImplementedError()
+    def delete(self, txid, store, entity, path):
+        '''Method definition for opendaylight-jsonrpc-data RPC `delete`.'''
+        raise NotImplementedError()
+    def commit(self, txid):
+        '''Method definition for opendaylight-jsonrpc-data RPC `commit`.'''
+        raise NotImplementedError()
+    def cancel(self, txid):
+        '''Method definition for opendaylight-jsonrpc-data RPC `cancel`.'''
+        raise NotImplementedError()
+    def error(self, txid):
+        '''Method definition for opendaylight-jsonrpc-data RPC `error`.'''
+        raise NotImplementedError()

--- a/python-inocybe-tree/inocybe_tree/pathmap.py
+++ b/python-inocybe-tree/inocybe_tree/pathmap.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python
+
+'''Path mapper
+
+YANG modeled JSON RPC 2.0 semantics.
+
+Paths are expressed as:
+    {"level1":{"level2":{}}} for containers. {} signifies the end.
+
+If a container contains:
+    {"level1":{"level2":1,"level2-more":2}} the above path will
+address 1.
+
+A path of {"level1":{}} will address {"level2":1,"level2-more":2}
+
+Each node in the path map has two "slots" to store "things" on it
+"data" and "meta".
+
+Meta is intended to store schema related information such as
+instances of classes responsible for mapping operations
+onto actual device operations.
+
+Data is intended to store actual data when the schema tree is used
+as a temporary scratchpad in data operations.
+
+'''
+
+class MetaMixin(object):
+    '''Metadata and Data base mixin for yang tree'''
+    def __init__(self):
+        self._metadata = None
+        self._data = None
+        self._validator = None
+
+    @property
+    def validator(self):
+        '''Get metadata'''
+        return self._validator
+
+    @validator.setter
+    def validator(self, val):
+        '''metadata setter'''
+        self._validator = val
+
+    @property
+    def meta(self):
+        '''Get metadata'''
+        return self._metadata
+
+    @meta.setter
+    def meta(self, val):
+        '''metadata setter'''
+        self._metadata = val
+
+    @property
+    def data(self):
+        '''Get data'''
+        return self._data
+
+    @data.setter
+    def data(self, val):
+        '''Data setter'''
+        if self._validator is not None:
+            self._data = self._validator(val)
+        else:
+            self._data = val
+
+class PathMapContainerElement(dict, MetaMixin):
+    '''Dict with metadata'''
+    def __init__(self, val):
+        dict.__init__(self, {})
+        for (key, value) in val.items():
+            if isinstance(value, dict):
+                self[key] = PathMapContainerElement(value)
+            elif isinstance(value, list):
+                self[key] = PathMapListElement(value)
+            else:
+                self[key] = value
+
+        MetaMixin.__init__(self)
+
+class PathMapListElement(list, MetaMixin):
+    '''Yang List with metadata and a known key. Key is a tuple of
+       fields used for indexing (normal yang list semantics)'''
+    def __init__(self, val, key_fields=None):
+        MetaMixin.__init__(self)
+        list.__init__(self, [])
+        self._key_fields = key_fields
+        self._index = {}
+        for nested in val:
+            if len(nested) > 0:
+                self.append(PathMapContainerElement(nested))
+
+    def set_key(self, key_fields):
+        '''Set an index after the fact not at construction'''
+        self._key_fields = key_fields
+        self._index = {}
+        for item in self:
+            self._add_to_index(item)
+
+    def _form_key(self, val):
+        '''Create a key-value tupple which we can hash on'''
+        result = []
+        for key in self._key_fields:
+            result.append(key)
+            result.append(val[key])
+        return tuple(result)
+
+    def _add_to_index(self, val):
+        '''Add an element to the index'''
+        if self._key_fields is not None:
+            if self._form_key(val) in self._index:
+                raise KeyError("Duplicate Key")
+            else:
+                self._index[self._form_key(val)] = val
+
+    def _del_from_index(self, val):
+        '''Delete element to the index'''
+        if self._key_fields is not None:
+            del self._index[self._form_key(val)]
+
+    def append(self, val):
+        '''Index aware append version'''
+        self._add_to_index(val)
+        return super(PathMapListElement, self).append(val)
+
+    def extend(self, val):
+        '''Index aware extend version'''
+        for item in val:
+            self._add_to_index(item)
+        return super(PathMapListElement, self).extend(val)
+
+    def insert(self, i, pos):
+        '''Index aware insert version'''
+        self._add_to_index(i)
+        return super(PathMapListElement, self).insert(i, pos)
+
+    def remove(self, pos):
+        '''Index aware remove version'''
+        self.pop(pos)
+
+    def pop(self, pos=0):
+        '''Index aware pop version'''
+        result = super(PathMapListElement, self).pop(pos)
+        self._del_from_index(result)
+        return result
+
+    def _brute_force_lookup(self, val):
+        '''Lookup for the case where index is unavailable'''
+        for item in self:
+            found = True
+            for key in val.keys():
+                if item.get(key) != val[key]:
+                    found = False
+                    break
+            if found:
+                return item
+        return None
+
+    def lookup(self, val):
+        '''Lookup an element by key'''
+        if self._key_fields is not None:
+            return self._index[self._form_key(val)]
+        else:
+            return self._brute_force_lookup(val)
+
+class PathMap(object):
+    '''A class to map a YIId path or JSON RPC Draft path to an actual "fetch"
+       function'''
+    def __init__(self, inherit=True):
+        self._path_map = PathMapContainerElement({})
+        self._default_metadata = None
+        self._inherit = inherit
+
+    @staticmethod
+    def _do_container(path_map, path, create=False, inherit=True):
+        '''Dict case for walking a pathmap'''
+
+        key = None
+        next_item = None
+
+        try:
+            (key, next_item) = no_mayhem_pop(path)
+        except TypeError:
+            return path_map
+
+        if path_map.get(key) is None:
+            # Path does not exist in pathmap
+            if create:
+                if isinstance(next_item, dict):
+                    path_map[key] = PathMapContainerElement(next_item)
+                else:
+                    path_map[key] = PathMapListElement(next_item)
+            else:
+                if inherit:
+                    return path_map
+                else:
+                    return None
+
+        result = PathMap._do_element(path_map[key], next_item, create, inherit)
+        if (result is None) and inherit:
+            return path_map
+        return result
+
+    @staticmethod
+    def _do_list(path_map, path, create=False, inherit=True):
+        '''List case for walking a pathmap'''
+        item_key = {}
+        next_key = None
+        next_item = None
+        result = None
+
+        if len(path) == 0:
+            return path_map
+
+        for (key, value) in path[0].items():
+            if isinstance(value, dict) or isinstance(value, list):
+                next_key = key
+                next_item = value
+            else:
+                item_key[key] = value
+
+        if len(item_key) == 0:
+            return path_map
+
+        found = path_map.lookup(item_key)
+        if found is not None:
+            if next_key is None:
+                result = found
+            else:
+                try:
+                    result = PathMap._do_element(found[next_key], next_item, create, inherit)
+                except KeyError:
+                    result = found
+
+        if (not found) and create:
+            new_item = PathMapContainerElement(dict(path[0]))
+            path_map.append(new_item)
+            result = PathMap._do_container(new_item, path[0], create, inherit)
+
+        if (result is None) and inherit:
+            return path_map
+        else:
+            return result
+
+    @staticmethod
+    def _do_element(path_map, path, create=False, inherit=True):
+        '''Recursively descend down the tree creating it as needed
+           and honoring inheritance'''
+
+        # dict case
+        result = None
+        if isinstance(path, dict):
+            result = PathMap._do_container(path_map, path, create, inherit)
+
+        # list case
+        if isinstance(path, list):
+            result = PathMap._do_list(path_map, path, create, inherit)
+        return result
+
+    def mapnode(self, path):
+        '''Return the actual underlying node (not honoring inheritance)'''
+        return PathMap._do_element(self._path_map, path, inherit=False)
+
+    def mapnode_in_charge(self, path):
+        '''Return the actual underlying node - honoring inheritance)'''
+        return PathMap._do_element(self._path_map, path, inherit=True)
+
+    def create(self, path):
+        '''Return the actual underlying node (not honoring inheritance)'''
+        PathMap._do_element(self._path_map, path, inherit=False, create=True)
+
+    def metadata(self, path, metadata=None):
+        '''Attach or get a metadata elementto a part of the tree. Honors inheritance.
+           There is no restriction on the type of metadata element - it can be code,
+           object or a tooth fairy instance - up to the user.'''
+
+        result = PathMap._do_element(self._path_map, path, metadata is not None)
+        if result is not None:
+            if metadata is not None:
+                result.meta = metadata
+            return result.meta
+        return None
+
+    def export(self):
+        '''Dump the map in object only format (no hanlders)'''
+        return self._path_map
+
+    @staticmethod
+    def _container_to_data(path_map):
+        '''Dict case for convert to data'''
+
+        if len(path_map) > 0:
+            result = {}
+            for (key, next_item) in path_map.items():
+                next_level = PathMap._to_data(next_item)
+                if (next_level is not None) and (not next_level == {}):
+                    result[key] = next_level
+            return result
+        return path_map.data
+
+    @staticmethod
+    def _list_to_data(path_map):
+        '''List case for convert to data'''
+
+        result = []
+        for next_item in path_map:
+            result.append(PathMap._container_to_data(next_item))
+        return result
+
+    @staticmethod
+    def _to_data(path_map):
+        '''Recursively descend down the tree replacing all {} with
+           meta in their object if present, deleting otherwise'''
+
+        # dict case
+        if isinstance(path_map, dict):
+            return PathMap._container_to_data(path_map)
+
+        # list case
+        if isinstance(path_map, list):
+            return PathMap._list_to_data(path_map)
+        return path_map.data
+
+
+    def to_data(self):
+        '''Recursively descend down the tree replacing all {} with
+           meta in their object if present, deleting otherwise,
+           return the result'''
+        return PathMap._to_data(self._path_map)
+
+
+def no_mayhem_pop(val):
+    '''Non-destructive popitem'''
+    for (key, value) in val.items():
+        return (key, value)
+    return None

--- a/python-inocybe-tree/inocybe_tree/select.py
+++ b/python-inocybe-tree/inocybe_tree/select.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+
+'''Select data from a data tree.'''
+
+class Selector(object):
+    '''A selector for selecting data from a data tree, where the tree is composed from structured
+       Python values (dicts, lists) with atomic leaf data. A path, which is a similarly structured
+       Python value, is used to specify which data to select, starting from a context value of the
+       whole data tree:
+
+       * an empty dict or empty list selects the current context value;
+       * a non-empty dict whose pair values are all atomic values (a `match`) selects the current
+         context value if that value is a dict with a matching pair value for each pair in `match`;
+       * a non-empty dict with one pair value which is a structured value changes the context to the
+         value of that pair, if the current context is a dict which has a value for that pair; this
+         selection can be made conditional by specifying `match` pairs as above;
+       * a non-empty dict with more than one pair value which is a structured value selects a dict
+         formed by pairs whose values are selected from the current context value by changing the
+         context to the value of each such pair, if the current context is a dict which has a value
+         for that pair; this selection can be made conditional by specifying `match` pairs as above;
+       * a non-empty list with one item which is a structured value changes the context to the value
+         of the first item which satisfies the item selection, if the current context is a sequence;
+       * a non-empty list with multiple items which are structured values selects a list formed by
+         items whose values are selected from the current context value by changing the context to
+         the value of each item which satisfies the item selection in turn, if the current context
+         is a sequence.
+
+       Use :classmethod:`path` to create an instance from a `path`. Call the :meth:`select` method
+       of the instance to select data from a tree.
+    '''
+    @staticmethod
+    def select(data):
+        '''Return the data selected by this selector from the current context `data`. If a value
+           cannot be selected then return None.
+
+           This method selects and returns the current context `data`.
+        '''
+        return data
+    @classmethod
+    def path(cls, path, odl_kludge=False):
+        '''Create a selector from `path`. If `odl_kludge` is True, then `path` is assumed to have
+           been formed by ODL and any known errors in path formation shall be corrected.
+        '''
+        if isinstance(path, dict):
+            return _SelectorDict.path(path, odl_kludge)
+        elif isinstance(path, list):
+            return _SelectorList.path(path, odl_kludge)
+        else:
+            raise ValueError('bad path: {}'.format(path))
+
+class _SelectorDict(Selector):
+    def __init__(self, match, select):
+        Selector.__init__(self)
+        self._match = match
+        self._select = select
+    def select(self, data):
+        for key in self._match:
+            try:
+                if self._match[key] != data[key]:
+                    return None
+            except (KeyError, TypeError):
+                return None
+        if not self._select:
+            return data
+        selected = {}
+        for key in self._select:
+            selector = self._select[key]
+            try:
+                val = data[key]
+            except (KeyError, TypeError):
+                val = None
+            else:
+                val = selector.select(val)
+            if len(self._select) == 1:
+                return val
+            elif val is not None:
+                selected[key] = val
+        if selected:
+            return selected
+    @classmethod
+    def path(cls, path, odl_kludge=False):
+        if len(path) == 0:
+            return Selector()
+        match = {}
+        select = {}
+        for key in path:
+            val = path[key]
+            ### if `key` has a module prefix, discard it
+            try:
+                key = key.split(':', 1)[1]
+            except IndexError:
+                pass
+            try:
+                ### ODL misspecifies a list selector by wrapping it in a superfluous object selector
+                ### with the same YANG identifier: strip the superfluous selector as required.
+                if odl_kludge and isinstance(val[key], list):
+                    val = val[key]
+            except (KeyError, TypeError):
+                pass
+            try:
+                select[key] = Selector.path(val, odl_kludge)
+            except ValueError:
+                match[key] = val
+        return cls(match, select)
+
+class _SelectorList(Selector):
+    def __init__(self, select):
+        Selector.__init__(self)
+        self._select = select
+    def select(self, data):
+        selected = []
+        for selector in self._select:
+            try:
+                for val in data:
+                    val = selector.select(val)
+                    if val is None:
+                        continue
+                    elif len(self._select) == 1:
+                        return val
+                    else:
+                        selected.append(val)
+            except TypeError:
+                return None
+        if selected:
+            return selected
+    @classmethod
+    def path(cls, path, odl_kludge=False):
+        if len(path) == 0:
+            return Selector()
+        return cls([Selector.path(_) for _ in path])

--- a/python-inocybe-tree/inocybe_tree/tests/test_jsonrpc.py
+++ b/python-inocybe-tree/inocybe_tree/tests/test_jsonrpc.py
@@ -1,0 +1,71 @@
+'''Test cases for inocybe_tree.jsonrpc.'''
+
+from nose.tools import assert_equal
+from nose.tools import raises
+
+from inocybe_tree.jsonrpc import (DataRead, DataWrite)
+
+class TestDataRead(DataRead): ### pylint: disable=abstract-method
+    '''Test :class:`DataRead` method interface.'''
+    def __init__(self):
+        self.methods = {}
+        DataRead.__init__(self)
+    def test_methods(self):
+        '''Test inocybe_tree.jsonrpc.DataRead registers expected methods'''
+        assert_equal(self.methods, {
+            'exists': self.exists,
+            'read': self.read,
+        })
+    @raises(NotImplementedError)
+    def test_exists(self):
+        '''Test inocybe_tree.jsonrpc.DataRead.exists() method is abstract'''
+        self.exists(0, 'foo', {})
+    @raises(NotImplementedError)
+    def test_read(self):
+        '''Test inocybe_tree.jsonrpc.DataRead.read() method is abstract'''
+        self.read(0, 'foo', {})
+
+class TestDataWrite(DataWrite): ### pylint: disable=abstract-method
+    '''Test :class:`DataWrite` method interface.'''
+    def __init__(self):
+        self.methods = {}
+        DataWrite.__init__(self)
+    def test_methods(self):
+        '''Test inocybe_tree.jsonrpc.DataWrite registers expected methods'''
+        assert_equal(self.methods, {
+            'txid': self.txid,
+            'put': self.put,
+            'merge': self.merge,
+            'delete': self.delete,
+            'commit': self.commit,
+            'cancel': self.cancel,
+            'error': self.error,
+        })
+    @raises(NotImplementedError)
+    def test_txid(self):
+        '''Test inocybe_tree.jsonrpc.DataWrite.txid() method is abstract'''
+        self.txid()
+    @raises(NotImplementedError)
+    def test_put(self):
+        '''Test inocybe_tree.jsonrpc.DataWrite.put() method is abstract'''
+        self.put('my txid', 0, 'foo', {}, 'bar')
+    @raises(NotImplementedError)
+    def test_merge(self):
+        '''Test inocybe_tree.jsonrpc.DataWrite.merge() method is abstract'''
+        self.merge('my txid', 0, 'foo', {}, 'bar')
+    @raises(NotImplementedError)
+    def test_delete(self):
+        '''Test inocybe_tree.jsonrpc.DataWrite.delete() method is abstract'''
+        self.delete('my txid', 0, 'foo', {})
+    @raises(NotImplementedError)
+    def test_commit(self):
+        '''Test inocybe_tree.jsonrpc.DataWrite.commit() method is abstract'''
+        self.commit('my txid')
+    @raises(NotImplementedError)
+    def test_cancel(self):
+        '''Test inocybe_tree.jsonrpc.DataWrite.cancel() method is abstract'''
+        self.cancel('my txid')
+    @raises(NotImplementedError)
+    def test_error(self):
+        '''Test inocybe_tree.jsonrpc.DataWrite.error() method is abstract'''
+        self.error('my txid')

--- a/python-inocybe-tree/inocybe_tree/tests/test_pathmap.py
+++ b/python-inocybe-tree/inocybe_tree/tests/test_pathmap.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+
+'''Path mapper test
+'''
+
+from inocybe_tree.pathmap import PathMap
+from inocybe_tree.pathmap import PathMapListElement
+
+from nose.tools import ok_ as assert_
+from nose.tools import raises
+from nose.tools import assert_equal
+from nose.tools import assert_is_none
+
+TEST_LIST = [
+        {"key":1, "value":"a"},
+        {"key":2, "value":"b"},
+        {"key":3, "value":"c"},
+        {"key":4, "value":"d"},
+        {"key":5, "value":"e"},
+        {"key":6, "value":"f"},
+        {"key":7, "value":"g"},
+        {"key":8, "value":"h"},
+        {"key":9, "value":"i"},
+        {"key":10, "value":"j"}
+]
+
+def test_list_element():
+    '''Test the accelerated list functionality'''
+    pl = PathMapListElement([])
+    pl.extend(TEST_LIST)
+    lk = pl.lookup({"key":9})
+    assert_equal(lk["value"], "i")
+    assert_equal(lk["key"], 9)
+    pl.set_key(("key",))
+    assert_equal(lk["value"], "i")
+    assert_equal(lk["key"], 9)
+
+def test_container_path():
+    '''Basic container path mapping'''
+    pm = PathMap()
+    # basic set - simple two level path, get back the metadata upon creation
+    # set to 1
+    assert_equal(pm.metadata({"level1":{"level2":{}}}, 1), 1)
+    # basic get - double check the metadata for same path a step later
+    # set to 1 in previous step
+    assert_equal(pm.metadata({"level1":{"level2":{}}}), 1)
+    # basic failed get
+    # we have no higher level inherited value and we give a wrong path - should
+    # get none
+    assert_is_none(pm.metadata({"level1":{"level2-wrong":{}}}))
+    # basic inherited get
+    # we now try a "wrong" (actually inexistent path) under a level where we
+    # have something set
+    import sys
+    sys.stderr.write("EXPORT {} DATA {}".format(pm.export(), pm.to_data()))
+    assert_equal(pm.metadata({"level1":{"level2":{"level3":{}}}}), 1)
+
+def test_list_path():
+    '''Basic list path mapping'''
+    pm = PathMap()
+    # basic set of metadata for whole list
+    assert_equal(pm.metadata({"level1":[{}]}, 1), 1)
+    # basic get of metadata for whole list
+    assert_equal(pm.metadata({"level1":[{}]}), 1)
+    # basic failed get - for whole list
+    assert_is_none(pm.metadata({"level1-wrong":[{}]}))
+    # basic inherited get - we have something set for whole list, 
+    # an element should inherit it
+    assert_equal(pm.metadata({"level1":[{"level2":"level2-value"}]}), 1)
+
+def test_list_item_path():
+    '''list path mapping - item level'''
+    pm = PathMap()
+    # basic set to a list item
+    assert_equal(pm.metadata({"level1":[{"level2":"level2-value"}]}, 1), 1)
+    # basic get for a list item
+    assert_equal(pm.metadata({"level1":[{"level2":"level2-value"}]}), 1)
+    # basic get - nothing set at the to list level, we have messed only with
+    # elements
+    assert_is_none(pm.metadata({"level1":[{}]}))
+    # basic inherited get
+    # we have set metadata for {"level1":[{"level2":"level2-value"}]} to 1, subelements
+    # inherit so a path under this will have 1 until we change to otherwise
+    assert_equal(pm.metadata({"level1":[{"level2":"level2-value", "content":{}}]}), 1)
+    # wrong key failed get
+    assert_is_none(pm.metadata({"level1":[{"level2":"level3-value"}]}))
+    # wrong key look in depth failed get
+    assert_is_none(pm.metadata({"level1":[{"level2":"level3-value", "content":{}}]}))
+
+def test_list_item_complex_map ():
+    '''list path mapping - item level, multiple items present'''
+    # same as above, just a more complex use case where there are multiple list
+    # items
+    pm = PathMap()
+    # basic set
+    assert_equal(pm.metadata({"level1":[{"level2":"level2-value1"}]}, 1), 1)
+    assert_equal(pm.metadata({"level1":[{"level2":"level2-value2"}]}, 2), 2)
+    # basic get 1
+    assert_equal(pm.metadata({"level1":[{"level2":"level2-value1"}]}), 1)
+    # basic get 2
+    assert_equal(pm.metadata({"level1":[{"level2":"level2-value2"}]}), 2)
+    # basic failed get
+    assert_is_none(pm.metadata({"level1":[{}]}))
+    # basic inherited get
+    assert_equal(pm.metadata({"level1":[{"level2":"level2-value1", "content":{}}]}), 1)
+    # basic inherited get
+    assert_equal(pm.metadata({"level1":[{"level2":"level2-value2", "content":{}}]}), 2)
+    # wrong key failed get
+    assert_is_none(pm.metadata({"level1":[{"level2":"level3-value"}]}))
+    # wrong key look in depth failed get
+    assert_is_none(pm.metadata({"level1":[{"level2":"level3-value", "content":{}}]}))
+
+def test_list_item_complex_map_take_2 ():
+    '''list path mapping - item level, multiple items present, metadata on list'''
+    pm = PathMap()
+    # same as above, just a more complex use case where there are multiple list
+    # items and inheritance into the mix
+    assert_equal(pm.metadata({"level1":[{}]}, "list"), "list")
+    assert_equal(pm.metadata({"level1":[{}]}), "list")
+    assert_equal(pm.metadata({"level1":[{"level2":"level2-value1"}]}, 1), 1)
+    assert_equal(pm.metadata({"level1":[{"level2":"level2-value2"}]}, 2), 2)
+    # basic get 1
+    assert_equal(pm.metadata({"level1":[{"level2":"level2-value1"}]}), 1)
+    # basic get 2
+    assert_equal(pm.metadata({"level1":[{"level2":"level2-value2"}]}), 2)
+    # basic failed get
+    # basic inherited get
+    assert_equal(pm.metadata({"level1":[{"level2":"level2-value1", "content":{}}]}), 1)
+    # basic inherited get
+    assert_equal(pm.metadata({"level1":[{"level2":"level2-value2", "content":{}}]}), 2)
+    # wrong key failed get
+    assert_equal(pm.metadata({"level1":[{"level2":"level3-value"}]}), "list")
+    # wrong key look in depth failed get
+    assert_equal(pm.metadata({"level1":[{"level2":"level3-value", "content":{}}]}), "list")
+
+def test_list_item_multiple_elements():
+    '''list path mapping - item level, multiple items present, details for elements'''
+    pm = PathMap()
+    # same as above, use direct access to verify member content
+    pm.create({"level1":[{"level2":"level3-value", "content":{}}]})
+    pm.mapnode({"level1":[{"level2":"level3-value", "content":{}}]}).meta = "list"
+    assert_equal(pm.metadata({"level1":[{"level2":"level3-value", "content":{}}]}), "list")
+    assert_equal(pm.mapnode({"level1":[{"level2":"level3-value", "content":{}}]}), {})
+    assert_equal(pm.mapnode({"level1":[{"level2":"level3-value"}]})["level2"], "level3-value")
+    assert_equal(pm.mapnode({"level1":[{"level2":"level3-value"}]})["content"], {})
+
+
+#def test_data_mapping():
+#    # use the pathmap to stash data and ask for data back instead of pathmap or metadata
+#    pm = PathMap()
+#    pm.create({"level1":[{"level2":"level3-value", "content":{}}]})
+#    pm.mapnode({"level1":[{"level2":"level3-value", "content":{}}]}).meta = "list"
+#    assert_equal(pm.to_data()['level1'][0]['content'], "list")
+#    assert_equal(pm.to_data()['level1'][0]['level2'], "level3-value")

--- a/python-inocybe-tree/inocybe_tree/tests/test_select.py
+++ b/python-inocybe-tree/inocybe_tree/tests/test_select.py
@@ -1,0 +1,286 @@
+'''Test cases for inocybe_tree.select.'''
+
+from nose.tools import assert_equal
+from nose.tools import raises
+
+from inocybe_tree.select import Selector
+
+def test_selector_bad_path():
+    '''Test :class:`Selector` rejects bad path.'''
+    for bad in (None, False, True, -7, 0, -3.2, 'foo', ['not a selector']):
+        func = raises(ValueError)(lambda b=bad: Selector.path(b))
+        fmt = 'Test inocybe_tree.select.Selector.path() rejects path {}'
+        func.description = fmt.format(bad)
+        yield func
+
+class _TestPath(object): ### pylint: disable=too-few-public-methods
+    '''Test :class:`Selector` with valid path.'''
+    ### the path to test
+    path = None
+    ### a sequence of 2-tuples (input data, output selected)
+    selects = ()
+    def __init__(self):
+        ### always turn on the odl_kludge: TestOdl* classes exercise the kludge
+        self._selector = Selector.path(self.path, odl_kludge=True)
+    def test_selects(self):
+        '''Test Selector.select for input/output pairs in :attr:`selects`.'''
+        for (input_, output) in self.selects:
+            func = lambda s=self._selector, i=input_, o=output: assert_equal(o, s.select(i))
+            fmt = 'Test inocybe_tree.select.Selector() with path {} selects {} from {}'
+            func.description = fmt.format(self.path, output, input_)
+            yield func
+
+class TestDictGoal(_TestPath): ### pylint: disable=too-few-public-methods
+    '''Test :class:`Selector` with dict path for select goal.'''
+    path = {}
+    selects = (
+        (None, None),
+        (False, False),
+        (True, True),
+        (-7, -7),
+        (0, 0),
+        (-3.2, -3.2),
+        ('foo', 'foo'),
+        ([], []),
+        (['foo', 'bar'], ['foo', 'bar']),
+        ({}, {}),
+        ({'foo': 'bar'}, {'foo': 'bar'}),
+    )
+
+class TestDictMatch(_TestPath): ### pylint: disable=too-few-public-methods
+    '''Test :class:`Selector` with dict path for select match.'''
+    path = {'foo': 'bar'}
+    selects = (
+        (None, None),
+        (False, None),
+        (True, None),
+        (-7, None),
+        (0, None),
+        (-3.2, None),
+        ('foo', None),
+        ([], None),
+        (['foo', 'bar'], None),
+        ({}, None),
+        ({'foo': 'quux'}, None),
+        ({'foo': 'bar'}, {'foo': 'bar'}),
+        ({'baz': 'quux'}, None),
+        ({'foo': 'bar', 'baz': 'quux'}, {'foo': 'bar', 'baz': 'quux'}),
+    )
+
+class TestDictSingle(_TestPath): ### pylint: disable=too-few-public-methods
+    '''Test :class:`Selector` with dict path for select single pair value.'''
+    path = {'foo': {}}
+    selects = (
+        (None, None),
+        (False, None),
+        (True, None),
+        (-7, None),
+        (0, None),
+        (-3.2, None),
+        ('foo', None),
+        ([], None),
+        (['foo', 'bar'], None),
+        ({}, None),
+        ({'foo': 'bar'}, 'bar'),
+    )
+
+class TestDictMultiple(_TestPath): ### pylint: disable=too-few-public-methods
+    '''Test :class:`Selector` with dict path for select multiple pair values.'''
+    path = {'foo': {}, 'bar': {}, 'baz': {}}
+    selects = (
+        (None, None),
+        (False, None),
+        (True, None),
+        (-7, None),
+        (0, None),
+        (-3.2, None),
+        ('foo', None),
+        ([], None),
+        (['foo', 'bar'], None),
+        ({}, None),
+        ({'foo': 'wibble'}, {'foo': 'wibble'}),
+        ({'foo': 'wibble', 'quux': 'thud'}, {'foo': 'wibble'}),
+        ({'bar': 'xyxxz', 'baz': 'thud'}, {'bar': 'xyxxz', 'baz': 'thud'}),
+        ({'wibble': 'thud'}, None),
+    )
+
+class TestDictMatchSingle(_TestPath): ### pylint: disable=too-few-public-methods
+    '''Test :class:`Selector` with dict path for select match and single pair value.'''
+    path = {'foo': 'bar', 'baz': {}}
+    selects = (
+        (None, None),
+        (False, None),
+        (True, None),
+        (-7, None),
+        (0, None),
+        (-3.2, None),
+        ('foo', None),
+        ([], None),
+        (['foo', 'bar'], None),
+        ({}, None),
+        ({'foo': 'bar'}, None),
+        ({'baz': 'quux'}, None),
+        ({'foo': 'bar', 'baz': 'quux'}, 'quux'),
+    )
+
+class TestDictMatchMultiple(_TestPath): ### pylint: disable=too-few-public-methods
+    '''Test :class:`Selector` with dict path for select match and select multiple pair values.'''
+    path = {'foo': 'bar', 'baz': {}, 'quux': {}}
+    selects = (
+        (None, None),
+        (False, None),
+        (True, None),
+        (-7, None),
+        (0, None),
+        (-3.2, None),
+        ('foo', None),
+        ([], None),
+        (['foo', 'bar'], None),
+        ({}, None),
+        ({'baz': 'thud'}, None),
+        ({'baz': 'thud', 'quux': 'wibble'}, None),
+        ({'foo': 'bar'}, None),
+        ({'foo': 'bar', 'xyxxz': 'quuz'}, None),
+        ({'foo': 'bar', 'baz': 'thud'}, {'baz': 'thud'}),
+        ({'foo': 'bar', 'baz': 'thud', 'quux': 'wibble'}, {'baz': 'thud', 'quux': 'wibble'}),
+    )
+
+class TestListGoal(_TestPath): ### pylint: disable=too-few-public-methods
+    '''Test :class:`Selector` with list path for select goal.'''
+    path = []
+    selects = (
+        (None, None),
+        (False, False),
+        (True, True),
+        (-7, -7),
+        (0, 0),
+        (-3.2, -3.2),
+        ('foo', 'foo'),
+        ([], []),
+        (['foo', 'bar'], ['foo', 'bar']),
+        ({}, {}),
+        ({'foo': 'bar'}, {'foo': 'bar'}),
+    )
+
+class TestListSingleWhole(_TestPath): ### pylint: disable=too-few-public-methods
+    '''Test :class:`Selector` with list path to select a single whole item.'''
+    path = [{'foo': 'bar'}]
+    selects = (
+        (None, None),
+        (False, None),
+        (True, None),
+        (-7, None),
+        (0, None),
+        (-3.2, None),
+        ('foo', None),
+        ([], None),
+        (['foo', 'bar'], None),
+        ([{}], None),
+        ([{'baz': 'quuz'}], None),
+        ([{'foo': 'bar', 'baz': 'quuz'}, {'foo': 'bar'}], {'foo': 'bar', 'baz': 'quuz'}),
+        ({}, None),
+        ({'foo': 'bar'}, None),
+    )
+
+class TestListSingle(_TestPath): ### pylint: disable=too-few-public-methods
+    '''Test :class:`Selector` with list path to select a single item pair value.'''
+    path = [{'foo': 'bar', 'baz': {}}]
+    selects = (
+        (None, None),
+        (False, None),
+        (True, None),
+        (-7, None),
+        (0, None),
+        (-3.2, None),
+        ('foo', None),
+        ([], None),
+        (['foo', 'bar'], None),
+        ([{}], None),
+        ([{'baz': 'quuz'}], None),
+        ([{'foo': 'bar', 'baz': 'quuz'}, {'foo': 'bar'}], 'quuz'),
+        ({}, None),
+        ({'foo': 'bar'}, None),
+    )
+
+class TestListMultiple(_TestPath): ### pylint: disable=too-few-public-methods
+    '''Test :class:`Selector` with list path to select multiple items.'''
+    path = [{'foo': 'bar'}, {'foo': 'bar', 'baz': {}}]
+    selects = (
+        (None, None),
+        (False, None),
+        (True, None),
+        (-7, None),
+        (0, None),
+        (-3.2, None),
+        ('foo', None),
+        ([], None),
+        (['foo', 'bar'], None),
+        ([{}], None),
+        ([{'baz': 'quuz'}], None),
+        ([{'foo': 'bar', 'baz': 'quuz'}, {'foo': 'bar'}], [
+            {'foo': 'bar', 'baz': 'quuz'}, {'foo': 'bar'}, 'quuz',
+        ]),
+        ({}, None),
+        ({'foo': 'bar'}, None),
+    )
+
+class TestOdlList(_TestPath): ### pylint: disable=too-few-public-methods
+    '''Test :class:`Selector` with ODL list path.'''
+    path = {'foo:bar': {'bar': [{'baz': 'quux', 'wibble': {}}]}}
+    selects = (
+        (None, None),
+        (False, None),
+        (True, None),
+        (-7, None),
+        (0, None),
+        (-3.2, None),
+        ('foo', None),
+        ([], None),
+        (['foo', 'bar'], None),
+        ({}, None),
+        ({'foo': 'bar'}, None),
+        ({'foo:bar': {'bar': [{'baz': 'quux', 'wibble': 'xyxxz'}]}}, None),
+        ({'bar': {'bar': [{'baz': 'quux', 'wibble': 'xyxxz'}]}}, None),
+        ({'foo:bar': [{'baz': 'quux', 'wibble': 'xyxxz'}]}, None),
+        ({'bar': [{'baz': 'quux', 'wibble': 'xyxxz'}]}, 'xyxxz'),
+        ({'foo:bar': [{'foo': 'bar'}, {'baz': 'quux', 'wibble': 'xyxxz'}]}, None),
+        ({'bar': [{'foo': 'bar'}, {'baz': 'quux', 'wibble': 'xyxxz'}]}, 'xyxxz'),
+    )
+
+class TestOdlNestedList(_TestPath): ### pylint: disable=too-few-public-methods
+    '''Test :class:`Selector` with ODL nested list path.'''
+    path = {
+        'foo:bar': {
+            'bar': [{
+                'baz': 'quux',
+                'wibble': [{
+                    'quuz': 'xyxxz',
+                    'thud': {},
+                }]
+            }],
+        },
+    }
+    selects = (
+        (None, None),
+        (False, None),
+        (True, None),
+        (-7, None),
+        (0, None),
+        (-3.2, None),
+        ('foo', None),
+        ([], None),
+        (['foo', 'bar'], None),
+        ({}, None),
+        ({'foo': 'bar'}, None),
+        ({'foo:bar': {'bar': [{'baz': 'quux', 'wibble': 'xyxxz'}]}}, None),
+        ({'bar': {'bar': [{'baz': 'quux', 'wibble': 'xyxxz'}]}}, None),
+        ({'foo:bar': [{'baz': 'quux', 'wibble': 'xyxxz'}]}, None),
+        ({'bar': [{'baz': 'quux', 'wibble': 'xyxxz'}]}, None),
+        ({'foo:bar': [{'baz': 'quux', 'wibble': [{'quuz': 'xyxxz', 'thud': True}]}]}, None),
+        ({'bar': [{'baz': 'quux', 'wibble': [{'quuz': 'xyxxz', 'thud': True}]}]}, True),
+        ({'bar': [
+            {'foo': 'bar'}, {'baz': 'quux', 'wibble': [
+                {'foo': 'bar'}, {'quuz': 'xyxxz', 'thud': 99},
+            ]},
+        ]}, 99),
+    )

--- a/python-inocybe-tree/setup.cfg
+++ b/python-inocybe-tree/setup.cfg
@@ -1,0 +1,6 @@
+[nosetests]
+verbosity=3
+detailed-errors=1
+with-coverage=1
+cover-package=inocybe_tree
+debug=nose.loader


### PR DESCRIPTION
Code and models needed to consume and produce CPS data
from python using datastructures which match RFC7951 or
netconf via direct serialization/deserialization.

Signed-off-by: Anton Ivanov <anton.ivanov@cambridgegreys.com>