### PR TITLE
Update models and parser to changes in OPX3.x

### DIFF
--- a/python-inocybe-openswitch/inocybe_openswitch/map.py
+++ b/python-inocybe-openswitch/inocybe_openswitch/map.py
@@ -592,12 +592,24 @@ def _fix_fec_from_cps(data):
 REV_BREAKOUT_MODE_MAP = {1:"DISABLED",
 2:"BREAKOUT_4x1",
 3:"BREAKOUT_2x1",
-4:"BREAKOUT_1x1"
+4:"BREAKOUT_1x1",
+5:"BREAKOUT_8x2",
+6:"BREAKOUT_2x2",
+7:"BREAKOUT_4x4",
+8:"BREAKOUT_2x4",
+9:"BREAKOUT_4x2",
+10:"BREAKOUT_UNKNOWN"
 }
 OUT_BREAKOUT_MODE_MAP = {"DISABLED":1,
 "BREAKOUT_4x1":2,
 "BREAKOUT_2x1":3,
-"BREAKOUT_1x1":4
+"BREAKOUT_1x1":4,
+"BREAKOUT_8x2":5,
+"BREAKOUT_2x2":6,
+"BREAKOUT_4x4":7,
+"BREAKOUT_2x4":8,
+"BREAKOUT_4x2":9,
+"BREAKOUT_UNKNOWN":10
 }
 
 def _fix_breakout_mode_to_cps(data):
@@ -960,6 +972,26 @@ def _fix_range_type_from_cps(data):
     '''Convert range type from CPS'''
     return IN_RANGE_TYPE_MAP[data]
 
+IN_FILTER_TYPE_MAP = {1:"DISABLE", 
+2:"ENABLE", 
+3:"INGRESS_ENABLE", 
+4:"EGRESS_ENABLE", 
+}
+OUT_FILTER_TYPE_MAP = {"DISABLE":1,
+"ENABLE":2,
+"INGRESS_ENABLE":3,
+"EGRESS_ENABLE":4,
+}
+
+def _fix_filter_type_to_cps(data):
+    '''Fix range type to CPS'''
+    return OUT_FILTER_TYPE_MAP[data]
+
+def _fix_filter_type_from_cps(data):
+    '''Convert range type from CPS'''
+    return IN_FILTER_TYPE_MAP[data]
+
+DO_FILTER_TYPE = (_fix_filter_type_to_cps, _fix_filter_type_from_cps)
 DO_RANGE_TYPE = (_fix_range_type_to_cps, _fix_range_type_from_cps)
 DO_PACKET_COLOR = (_fix_packet_color_to_cps, _fix_packet_color_from_cps)
 DO_STAGE = (_fix_stage_to_cps, _fix_stage_from_cps)
@@ -1010,6 +1042,7 @@ GLOBAL_MAP = TypeMap({'base-ip/ipv4/forwarding': DO_BOOL,
            'base-acl/entry/action/type':DO_ACTION_TYPE,
            'base-acl/table/allowed-match-fields':DO_MATCH_TYPE,
            'base-acl/table/stage':DO_STAGE,
+           'dell-base-if-cmn/if/interfaces/interface/vlan-filter':DO_FILTER_TYPE,
            })
 
 

--- a/python-inocybe-openswitch/models/base-alms.yang
+++ b/python-inocybe-openswitch/models/base-alms.yang
@@ -1,0 +1,35 @@
+module base-alms {
+
+  namespace "http://www.dellemc.com/networking/os10/dell-base-alms";
+
+  prefix "base-alms";
+
+  organization "Dell EMC";
+
+  contact "http://www.dell.com/support";
+
+  description "Alarm objects
+
+  Copyright (c) 2017 by Dell, Inc.
+
+  All rights reserved.";
+
+  revision 2017-03-02 {
+    description "Initial revision.";
+  }
+
+  list active-alms {
+       config false;
+       description "List of active alarms";
+
+       leaf timestamp {
+           description "Time alarm occurred";
+           type string;
+       }
+
+       leaf alarm {
+       	   description "Alarm message";
+           type string;
+       }
+  }
+}

--- a/python-inocybe-openswitch/models/base-common.yang
+++ b/python-inocybe-openswitch/models/base-common.yang
@@ -37,6 +37,37 @@ module base-common {
        physical ports, LAG interfaces and Vlan interfaces";
   }
 
+   typedef vni {
+     type uint32 {
+         range "1 .. 16777215";
+     }
+     description
+       "This type denotes a VXLAN Network Identifier.
+        It is 24 bits long. Hence 16 million such unique ID's are possible";
+   }
+
+   typedef filter-type {
+       type enumeration {
+           enum DISABLE {
+               value 1;
+               description "Operation to disable both ingress and egress filtering";
+           }
+           enum ENABLE {
+               value 2;
+               description "Operation to enable both ingress and egress filtering";
+           }
+           enum INGRESS_ENABLE {
+               value 3;
+               description "Operation to enable only ingress filtering";
+           }
+           enum EGRESS_ENABLE {
+               value 4;
+               description "Operation to enable only egress filtering";
+           }
+        }
+    }
+
+
   typedef npu-id {
     type uint32;
     description
@@ -250,6 +281,19 @@ module base-common {
       enum "vrf" {
         value 12;
       }
+       enum "macvlan" {
+         value 13;
+       }
+       enum "vxlan" {
+         value 14;
+       }
+       enum "bridge" {
+         value 15;
+       }
+       enum "vlan_subintf" {
+         value 16;
+       }
+
     }
     description
       "Enumeration of the various support interface types";
@@ -436,6 +480,15 @@ module base-common {
       enum BREAKOUT_4x2 {
         value 9; /* 4 logical interfaces derived from 2 front panel ports */
       }
+      enum BREAKOUT_UNKNOWN {
+        value 10; /* The breakout mode cannot be determined */
+ 	description "breakout is not identified due to unknown reason(s).";
+      }
+      enum NO_BREAKOUT {
+         value 11; /* Device does not breakout  */
+ 	description "breakout is not supported on the given port(s).";
+      }
+
     }
   }
 }

--- a/python-inocybe-openswitch/models/base-env-tempctl.yang
+++ b/python-inocybe-openswitch/models/base-env-tempctl.yang
@@ -1,0 +1,152 @@
+module base-env-tempctl {
+  namespace "http://www.dellemc.com/networking/os10/dell-base-env-tempctl";
+  prefix base-env-tempctl;
+
+  import base-platform-common {
+    prefix platform;
+  }
+
+  organization "Dell EMC";
+  contact
+    "http://www.dell.com/support";
+  description
+    "Environmental temperature control service manages various aspects including:
+     1) fan speed control (FSC),
+     2) temperature fault events handling,
+     3) logging of events and faults,
+     4) exception handling.
+
+     This model implements the configuration and Operational Data
+     related to this service.
+
+     Copyright (c) 2015-2018 by Dell EMC, All rights reserved.";
+
+  revision 2018-03-30 {
+    description "Fixing pyang IETF errors and adding documentation to the model";
+    reference "Network Platform Abstraction";
+  }
+  revision 2015-08-17 {
+    description
+      "Cleanup according to new DELL OS10 yang modelling guidelines";
+    reference "Network Platform Abstraction";
+  }
+  revision 2015-08-17 {
+    description
+      "Adding ability to set threshold values for various severity levels";
+    reference "Network Platform Abstraction";
+  }
+  revision 2015-05-20 {
+    description
+      "Moved fault-value type to dell-base-platform-common.yang";
+    reference "Network Platform Abstraction";
+  }
+  revision 2015-05-08 {
+    description
+      "Clean-up according to DELL OS10 yang Modelling guidelines";
+    reference "Network Platform Abstraction";
+  }
+  revision 2015-04-29 {
+    description
+      "Initial revision.";
+    reference "Network Platform Abstraction";
+  }
+
+
+  list fault {
+
+    // QUALIFIER: Target
+
+    key "entity-type slot sensor-name";
+
+    leaf entity-type {
+        type platform:entity-type;
+        description "Entity type";
+    }
+
+    leaf slot {
+        type uint8;
+        description "Entity slot";
+    }
+
+    leaf sensor-name {
+      type string;
+      description "Printable name for sensor";
+    }
+
+    leaf temperature {
+      type platform:temperature-type;
+      config false;
+      description "Current temperature of the sensor showing tc-fault";
+    }
+
+    leaf fault-type {
+        type platform:fault-severity;
+        config false;
+        description "Severity of current temperature control fault present";
+    }
+    description
+      "Attributes of environmental temperature control service's faults";
+  }
+
+  list fault-threshold {
+
+    // QUALIFIER: Target
+
+    key "entity-type slot sensor-name severity";
+
+    leaf entity-type {
+        type platform:entity-type;
+        description "Entity type";
+    }
+
+    leaf slot {
+        type uint8;
+        description "Entity slot";
+    }
+
+    leaf sensor-name {
+      type string;
+      description "Printable name for sensor";
+    }
+
+    leaf severity {
+      type platform:fault-severity;
+      description "Severity level of a temperature control fault";
+    }
+
+    leaf threshold {
+      type platform:temperature-type;
+      config true;
+      description "threshold temperature corresponding to severity above";
+    }
+    description
+      "Mapping of tc-fault's severity levels to threshold values";
+  }
+
+  list entity-fault {
+    description
+      "Entity faults";
+
+    key "entity-type slot";
+
+    leaf entity-type {
+        description "Entity type";
+        type platform:entity-type;
+    }
+
+    leaf slot {
+        description "Entity slot";
+        type uint8;
+    }
+
+    leaf ppid {
+        description "True <=> given entity has incorrect ppid";
+        type boolean;
+    }
+
+    leaf airflow {
+        description "True <=> given entity has incorrect airflow";
+        type boolean;
+    }
+  }
+}

--- a/python-inocybe-openswitch/models/base-etl-common.yang
+++ b/python-inocybe-openswitch/models/base-etl-common.yang
@@ -1,0 +1,108 @@
+module base-etl-common {
+
+    namespace "http://www.dellemc.com/networking/os10/dell-base-etl-common";
+
+    prefix base-etl-common;
+
+    organization
+        "Dell EMC";
+
+    contact
+        "http://www.dell.com/support";
+
+    description
+        "This module contains a collection of common YANG definitions for ETL logging and event notification objects.";
+
+    revision 2018-03-30 {
+        description "Revised Version: IETF Compliance";
+        reference "Dell Proprietary";
+    }
+
+    revision 2015-04-21 {
+        description "Initial revision.";
+        reference "Dell Proprietary";
+    }
+
+    typedef severity-level-type {
+        type enumeration {
+            enum "log-emerg" {
+                value "0";
+                description "Emergency level - enum definition starts at 0 due to
+                             required mapping to Linux syslog severity level definitions";
+            }
+            enum "log-alert" {
+                value "1";
+                description "Alert level";
+            }
+            enum "log-crit" {
+                value "2";
+                description "Critical level";
+            }
+            enum "log-err" {
+                value "3";
+                description "Error level";
+            }
+            enum "log-warning" {
+                value "4";
+                description "Warning level";
+            }
+            enum "log-notice" {
+                value "5";
+                description "Notice level";
+            }
+            enum "log-info" {
+                value "6";
+                description "Info level";
+            }
+            enum "log-debug" {
+                value "7";
+                description "Debug level";
+            }
+        }
+        description "Enumeration of all possible values for log level";
+    }
+
+    typedef log-output-type {
+        type enumeration {
+            enum "console" {
+                value "1";
+                description "Console output";
+            }
+            enum "terminal-monitor" {
+                value "2";
+                description "Terminal monitor output";
+            }
+            enum "history" {
+                value "3";
+                description "History output";
+            }
+        }
+        description "Enumeration of all possible types of log output mechanisms";
+    }
+
+    typedef log-config-type {
+        type enumeration {
+            enum "buffer" {
+                value "1";
+                description "Buffer configuration";
+            }
+            enum "console" {
+                value "2";
+                description "Console configuration";
+            }
+            enum "terminal-monitor" {
+                value "3";
+                description "Terminal monitor configuration";
+            }
+            enum "history" {
+                value "4";
+                description "History configuration";
+            }
+            enum "all-log-enable" {
+                value "5";
+                description "All logging enable configuration";
+            }
+        }
+        description "Enumeration of possible locations where log output can be directed to";
+    }
+}

--- a/python-inocybe-openswitch/models/base-hash.yang
+++ b/python-inocybe-openswitch/models/base-hash.yang
@@ -1,0 +1,149 @@
+module base-hash {
+
+    namespace "http://www.dellemc.com/networking/os10/dell-base-hash";
+    prefix "base-traffic-hash";
+
+    organization
+        "Dell EMC";
+
+    contact
+        "http://www.dell.com/support";
+
+    description
+        "When several routing paths exist between two nodes,
+         and are equally good (in terms of capacity and
+         latency), it is desirable to share the traffic among them.
+         Two of the common techniques to use this mechanism Equal Cost Multipath (ECMP) routing and
+         Link aggregation (LAG).
+
+         In order to determine what is the desirable next-hop NPUs use applies various hashing techniques
+         on the incoming traffic.The hashing technique to be applied is determined based on the
+         incoming traffic type and the associated hashing-fields.
+
+         This YANG model contains a collection of YANG definitions for managing
+         these LAG/ECMP specific hashing techniques used in the NPUs.
+
+         Copyright (c) 2015-2018 by Dell EMC, All rights reserved.";
+
+    revision 2018-04-12 {
+        description "Fixing pyang IETF errors and adding documentiation to the model.";
+        reference "Network Platform Abstraction";
+    }
+
+    revision 2016-04-27 {
+        description "Initial version";
+        reference "Network Platform Abstraction";
+    }
+
+    typedef traffic {
+        type enumeration {
+    	    enum "ECMP_NON_IP" {
+    	    	value 1;
+		description "ECMP routing: flow of non-IP ethernet frames";
+    	    }
+    	    enum "LAG_NON_IP" {
+    	    	value 2;
+		description "LAG routing: flow of non-IP ethernet frames";
+    	    }
+    	    enum "ECMP_IPV4" {
+    	    	value 3;
+		description "ECMP routing: flow of IPv4 packets";
+    	    }
+    	    enum "ECMP_IPV4_IN_IPV4" {
+    	    	value 4;
+		description "ECMP routing: flow of IPv4 packets with
+                             IPv4 packets tunnelled inside them";
+    	    }
+    	    enum "ECMP_IPV6" {
+    	    	value 5;
+		description "ECMP routing: flow of IPv6 packets";
+    	    }
+    	    enum "LAG_IPV4" {
+    	    	value 6;
+		description "LAG routing: flow of IPv4 packets";
+    	    }
+    	    enum "LAG_IPV4_IN_IPV4" {
+    	    	value 7;
+		description "ECMP routing: flow of IPv4 packets with
+                             IPv4 packets tunnelled inside them";
+    	    }
+    	    enum "LAG_IPV6" {
+    	    	value 8;
+		description "LAG routing: traffic flow is identified as IPv6 packets";
+    	    }
+        }
+        description "Enumeration of different types of traffic routing categories";
+    }
+
+    typedef field {
+        type enumeration {
+    	    enum "src-ip" {
+    	      value 1;
+              description "Traffic flow is identified by the source IP";
+    	    }
+    	    enum "dest-ip" {
+    	      value 2;
+              description "Traffic flow is identified by the destination IP";
+    	    }
+            enum "inner-src-ip" {
+              value 3;
+              description "Traffic flow is identified by the source IP of the tunnelled packet";
+            }
+            enum "inner-dst-ip" {
+              value 4;
+              description "Traffic flow is identified by the destination IP of the tunnelled packet";
+            }
+    	    enum "vlan-id" {
+    	      value 5;
+              description "Traffic flow is identified by the VLAN ID in the packet";
+    	    }
+    	    enum "ip-protocol" {
+    	      value 6;
+              description "Traffic flow is identified by the IP protocol type(v4/v6)";
+    	    }
+    	    enum "ethertype" {
+    	      value 7;
+              description "Traffic flow is identified by the IP protocol ether-type";
+    	    }
+    	    enum "l4-src-port" {
+    	      value 8;
+              description "Traffic flow is identified by the source port in the packet";
+    	    }
+    	    enum "l4-dest-port" {
+    	      value 9;
+              description "Traffic flow is identified by the destination port in the packet";
+    	    }
+    	    enum "src-mac" {
+    	      value 10;
+              description "Traffic flow is identified by the source MAC address";
+    	    }
+    	    enum "dest-mac" {
+    	      value 11;
+              description "Traffic flow is identified by the destination MAC address";
+    	    }
+    	    enum "in-port" {
+    	      value 12;
+              description "Traffic flow is identified by the front-panel port the packet is received at";
+    	    }
+        }
+        description "Enumeration of different types of packet fields to check for routing";
+    }
+
+    list entry {
+        key "obj-type";
+
+        // QUALIFIER : Target
+
+        leaf obj-type {
+            type traffic;
+            description "Type of the incoming traffic";
+        }
+
+        leaf-list std-hash-field {
+            type field;
+            description "A list of packet header fields used for hashing the incoming traffic";
+        }
+        description "Specifies the type of the incoming traffic and the associated hash-fields.";
+    }
+}
+

--- a/python-inocybe-openswitch/models/base-if-common.yang
+++ b/python-inocybe-openswitch/models/base-if-common.yang
@@ -1,7 +1,7 @@
 module base-if-common {
     namespace "http://www.dellemc.com/networking/os10/base/dell-base-if-common";
 
-    prefix "dell-base-if-cmn";
+    prefix "base-if-cmn";
 
     import ietf-interfaces {
         prefix "if";
@@ -88,11 +88,4 @@ module base-if-common {
                 attributes needed depends on requested interface type";
     }
 
-    augment "dell-if:clear-counters/dell-if:input" {
-
-    }
-
-    augment "dell-if:clear-eee-counters/dell-if:input" {
-
-    }
 }

--- a/python-inocybe-openswitch/models/base-if-vlan.yang
+++ b/python-inocybe-openswitch/models/base-if-vlan.yang
@@ -3,11 +3,10 @@ module base-if-vlan {
 
     prefix "base-if-vlan";
 
+    import iana-if-type { prefix "ianaift"; }
+
     import ietf-interfaces {
         prefix "if";
-    }
-    import ietf-yang-types {
-        prefix "yang";
     }
 	
     import base-common {

--- a/python-inocybe-openswitch/models/base-l2-mac.yang
+++ b/python-inocybe-openswitch/models/base-l2-mac.yang
@@ -1,0 +1,500 @@
+module base-l2-mac {
+
+    namespace "http://www.dellemc.com/networking/os10/dell-base-l2-mac";
+    prefix "base-mac";
+
+
+    import base-common {
+        prefix "base-cmn";
+    }
+
+  import base-interface-common { prefix "base-if"; }
+  import ietf-yang-types { prefix "yang"; }
+  import ietf-inet-types{ prefix "inet"; }
+
+    organization
+        "Dell EMC";
+
+    contact
+        "http://www.dell.com/support";
+
+    description
+        "This module contains a collection of YANG definitions provided
+         by OS10 base for managing MAC objects.This model is used to implement
+         show/clear MAC address-table.
+
+         Copyright(c) 2015-2018 by Dell EMC,
+         All rights reserved.";
+
+    revision "2018-05-20" {
+        description "Fixing pyang IETF errors and adding documentiation to the model.";
+        reference "Network Platform Abstraction";
+    }
+
+    revision "2018-05-01"{
+        description "Add enums to support MAC address flush for peer IP for all bridges and
+                     port VLAN subport";
+        reference "Network Platform Abstraction";
+    }
+
+    revision "2018-01-09" {
+        description "Added endpoint-event container to publish an event when endpoint is
+                     being added or deleted";
+        reference "Network Platform Abstraction";
+    }
+
+    revision "2017-10-10" {
+        description "Add forwarding table object. Add endpoint-ip, br-name attributes
+                     to support MAC addresses learned from remote endpoint";
+        reference "Network Platform Abstraction";
+    }
+
+    revision 2015-10-30 {
+        description
+            "Removed switch-id from key, updated some description";
+        reference "Network Platform Abstraction";
+    }
+
+    revision 2015-05-13 {
+        description
+            "Updated key, added command request type, added source drop packet action";
+        reference "Network Platform Abstraction";
+    }
+
+    revision 2014-12-31 {
+        description
+            "Initial revision";
+        reference "Network Platform Abstraction";
+    }
+    typedef packet-action {
+
+        type enumeration {
+            enum DROP {
+                value 1;
+                description
+                    "Do not forward, drop the packet if this entry is hit";
+            }
+            enum FORWARD {
+                value 2;
+                description
+                    "Forward the packet if this entry is hit";
+            }
+            enum TRAP {
+                value 3;
+                description
+                    "Copy the packet to CPU if this entry is hit";
+            }
+            enum LOG {
+                value 4;
+                description
+                    "Forward the packet and copy to the CPU
+                    if this entry is hit";
+            }
+            enum SOURCE_DROP {
+                value 5;
+                description
+                    "Discard the packet if incoming source matches this entry";
+            }
+        }
+        description "Enumeration of all possible actions to be performed on the matched packets";
+    }
+
+    typedef command-request-type {
+
+        type enumeration {
+            enum CMD_TYPE_VLAN {
+                value 1;
+                description
+                    "vlan specific command request";
+            }
+            enum CMD_TYPE_ADDRESS {
+                value 2;
+                description
+                    "mac address specific command request";
+            }
+            enum CMD_TYPE_INTERFACE {
+                value 3;
+                description
+                    "interface specific command request";
+            }
+            enum CMD_TYPE_COUNT {
+                value 4;
+                description
+                    "command request based on count option";
+            }
+            enum CMD_TYPE_ALL {
+                value 5;
+                description
+                    "command request for all details";
+            }
+        }
+        description "Enumeration of all possible request-type(s) to be used for 'show mac address-table'";
+    }
+
+     typedef mac-event-type {
+
+        type enumeration {
+            enum learnt {
+                value 1;
+                description
+                    "MAC address entry was learnt in npu";
+            }
+            enum aged {
+                value 2;
+                description
+                    "MAC address entry was aged out in npu";
+            }
+            enum flushed {
+                value 3;
+                description
+                    "MAC address entry was deleted in npu";
+            }
+            enum moved {
+            	value 4;
+            	description
+            		"MAC address entry was moved";
+    		}
+        }
+        description "Enumeration of all possible states of an entry in the MAC address-table";
+    }
+
+
+    typedef mac-flush-type {
+
+        type enumeration {
+            enum port {
+                value 1;
+                description
+                    "MAC address flush on the port";
+            }
+            enum vlan-port {
+                value 2;
+                description
+                    "MAC address flush on the given vlan port combination.
+                     This flush type is for port which is part of 1q VLAN";
+            }
+            enum vlan {
+                value 3;
+                description
+                    "MAC address flush on the given vlan";
+            }
+            enum all {
+            	value 4;
+            	description
+            		"MAC address flush on all vlan/ports";
+    		}
+    		
+            enum bridge {
+               value 5;
+                description
+                    "MAC address flush on the given bridge";
+            }
+
+            enum bridge-endpoint-ip {
+                value 6;
+                description
+                    "MAC address flush on the given bridge and
+                     endpoint ip address combination";
+            }
+
+            enum endpoint-ip {
+                value 7;
+                description
+                    "MAC address flush on the given
+                     endpoint ip address from all bridge where
+                     given ip is an overlay endpoint for the bridge";
+            }
+
+            enum vlan-port-subport {
+                value 8;
+                description
+                    "MAC address flush on the given subport which
+                     is a combination of VLAN id and port. This
+                     flush type is for port-vlan combination which is
+                     a subport of VLAN unaware(1d) bridge";
+            }
+        }
+        description "Enumeration of all possible ways to clear MAC address-table";
+    }
+
+    grouping entry {
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            status obsolete;
+            description
+                "Logical Switch to which this MAC entry belongs to";
+        }
+
+        leaf-list npu-id {
+            type base-cmn:npu-id;
+            description
+                "Optional subset of NPUs on which this MAC entry needs to be programmed.
+                If this attribute is not specified then the MAC entry will be created in all the NPUs
+                in the Logical switch to which the Entry belongs.";
+        }
+
+        leaf vlan {
+            type base-cmn:vlan-id;
+            description
+            	"VLAN ID to which MAC address entry belongs to in VLAN aware flooding domain.
+            	 For VLAN unaware flooding domain it is the vlan id of tagged access port";
+        }
+
+        leaf ifindex {
+            type base-cmn:logical-ifindex;
+            description
+                "System wide unique identifier of the interface
+                associated with this MAC entry.  This will be the physical port or LAG ifindex";
+        }
+
+      	leaf ifname {
+            type string;
+            description
+                "Interface name associated with this MAC entry";
+        }
+
+        leaf mac-address {
+            type yang:mac-address;
+            description
+                "MAC Address configured with this entry";
+        }
+
+        leaf static {
+            type boolean;
+            description
+                "Whether the MAC entry is configured as static. It will not age out";
+        }
+
+        leaf actions {
+            type packet-action;
+            description
+                "Action for packet when this MAC entry is hit";
+        }
+
+        leaf configure-os{
+            type boolean;
+            default false;
+            description
+                "If this entry needs to be configured in the OS";
+        }
+
+        leaf configure-npu{
+            type boolean;
+            default true;
+            description
+                "If this entry needs to be configured in the npu. Default behaviour is to
+                 configure it in the NPU";
+        }
+
+        leaf event-type{
+            type mac-event-type;
+            config false;
+            description
+                "When entry is published it will be published with the event type like learnt, aged, flushed";
+    	}
+
+        leaf publish{
+            type boolean;
+            default false;
+            description
+                "When entry is programmed by application in npu, if entry needs to be published";
+        }
+
+        container endpoint-ip {
+            uses inet:ip-address;
+            description
+                "Endpoint IP address for MAC address entries learned on remote endpoints";
+        }
+
+        leaf br-name{
+            type string;
+            description
+                "Bridge name where MAC address entry belongs.";
+         }
+        description "This list defines MAC entry";
+
+    }
+
+    list table {
+            // QUALIFIER : Target
+            key "vlan mac-address";
+
+            uses entry;
+            description
+                "MAC address table list for VLAN aware flooding domain.
+                 Each entry is uniquely identified by VLAN/MAC address combination within
+                 a switch domain";
+    }
+
+    list forwarding-table {
+            // QUALIFIER : Target
+            key "br-name mac-address";
+
+            uses entry;
+            description
+                "MAC address table for VLAN unaware flooding domain.
+                 Each entry is uniquely identified by Bridge name/MAC address
+                 combination within a switch domain";
+    }
+
+    list query {
+            // QUALIFIER : Target
+            key "vlan mac-address";
+
+            uses entry;
+
+            leaf request-type {
+                type command-request-type;
+                description
+                    "Command request type for data retrieval";
+            }
+
+            leaf count {
+                type uint32;
+                description
+                    "Count based on command request type";
+            }
+            description
+                "MAC entry specific query list";
+    }
+
+    container flush-management{
+        // QUALIFIER : Target
+
+        leaf enable{
+            type boolean;
+            default true;
+            description "To enable/disable auto flush of mac entries when
+            interface state changes";
+        }
+        description "To manage mac flush when interface status changes";
+    }
+
+    container list{
+        // QUALIFIER : Target
+        list entries{
+                key "br-name mac-address";
+                uses entry;
+                description "List of MAC entries to be published when event occurs in NPU.
+                             This will be published as a list.";
+        }
+        description "This container holds the entries list.";
+    }
+	
+    grouping flush{
+        leaf vlan {
+            type base-cmn:vlan-id;
+            description "Vlan ID where mac flush is to be done";
+        }
+
+        leaf ifindex {
+            type base-cmn:logical-ifindex;
+            description
+                  "System wide unique identifier of the interface
+                       where MAC flush is to be done.";
+        }
+
+        leaf ifname {
+            type string;
+            description
+                "Interface name associated with this MAC entry";
+        }
+
+        leaf br-name {
+            type string;
+            description
+                "Bridge interface name to which MAC address entry belongs to";
+        }	        	
+
+        container endpoint-ip {
+            uses inet:ip-address;
+            description
+                "Endpoint IP address for MAC address entries learned on remote endpoints";
+        }	
+
+        leaf all {
+            type boolean;
+            default false;
+            description
+                "By default only dynamic entries will be flushed. It this
+                 option is set then static and dynamic shall be flushed.";
+        }
+
+        leaf flush-type{
+    		type mac-flush-type;
+        	description
+        		"Type of the mac flush";
+		}
+        description "This grouping is to define the mac flush attributes";
+    }
+		
+		
+    container flush-event{
+     	config false;
+        list filter{
+        	uses flush;
+        	
+        	leaf-list member-ifindex{
+                    type base-cmn:logical-ifindex;
+                    description "leaf list of member interface indexes which were affected by the flush";
+                }	
+                description "List of MAC address-table flush events";
+    	}
+        description "MAC flush events to be published. This object is used only for publishing
+                     events.";
+        	
+    }
+
+    rpc flush {
+    description "Flush the MAC addresses learned on flooding domain,interface,
+                 flooding domain/interface, interface/remote ip ";
+
+    // ATTRIBUTE PATH  : base-mac/flush
+    // ==============
+    //
+    // QUALIFIER       : Target
+    // =========
+    //
+    // INPUT           : base-mac/flush/input/fliter (filter parameters chosen from the group 'flush')
+    // =====
+    //
+    // OUTPUT          : None
+    // ======
+
+    input {
+        list filter {
+                description "Flush input parameters which may include flooding domain name,
+                         interface name, flooding domain/interface name,
+                         interface/remote ip";
+        	uses flush;	
+            }
+        }
+    }
+
+    container tunnel-endpoint-event{
+        // QUALIFIER : Target
+
+        container ip{
+            uses inet:ip-address;
+            description
+                "IP address of the endpoint tunnel being added or deleted.";
+        }
+
+        leaf interface-name{
+            type string;
+            description
+                "Interface name of tunnel endpoint.";
+        }
+
+        leaf flooding-enable{
+            type boolean;
+            default false;
+            description
+                "Enable flooding to this tunnel endpoint.";
+        }
+        description "Event to be published when a new tunnel endpoint is being added or existing is
+                     being deleted.";
+
+    }
+}

--- a/python-inocybe-openswitch/models/base-media.yang
+++ b/python-inocybe-openswitch/models/base-media.yang
@@ -1,0 +1,74 @@
+module base-media {
+    namespace "http://www.dellemc.com/networking/os10/dell-base-media";
+    prefix "base-media";
+
+    import base-interface-common {
+        prefix "base-if";
+    }
+
+    import base-common {
+       prefix "base-cmn";
+    }
+
+    organization "Dell EMC";
+
+    contact "http://www.dell.com/support";
+
+    description "This model will support the configruation of params on interfaces";
+
+    revision 2016-01-11 {
+        description "Initial version.";
+    }
+
+    list media-info {
+        key "media-type";
+        description "This grouping defines the default settings for the media type";
+
+        leaf media-type {
+            config false;
+            type uint32;
+            description "The media type of the physical media";
+        }
+
+        leaf media-name {
+            config false;
+            type string;
+            description "The physical Media name";
+        }
+
+        leaf speed {
+            config false;
+            type base-if:speed;
+            description "default speed configuration for this physical media";
+        }
+
+        leaf autoneg {
+            config false;
+            type boolean;
+            description "default auto negotiation configuration for this physical media";
+        }
+
+        leaf duplex {
+            config false;
+            type base-cmn:duplex-type;
+            description "default duplex configuration for this physical media";
+        }
+
+        leaf hw-profile {
+            config false;
+            type uint32;
+            description "The hardware profile ID of the physical media";
+        }
+
+        leaf-list supported-speed {
+            config false;
+            type base-if:speed;
+            description " List of supported speed on this physical media";
+        }
+        leaf-list supported-phy-mode {
+            config false;
+            type base-if:phy-mode-type;
+            description " List of supported physical modes FC, ETHER on this physical media";
+        }
+    }
+}

--- a/python-inocybe-openswitch/models/base-mirror.yang
+++ b/python-inocybe-openswitch/models/base-mirror.yang
@@ -1,0 +1,204 @@
+module base-mirror {
+
+    namespace "http://www.dellemc.com/networking/os10/dell-base-mirror";
+    prefix "base-mirror";
+
+    import base-common {
+        prefix "base-cmn";
+    }
+    import ietf-inet-types {prefix "inet";}
+    import ietf-yang-types {prefix "yang";}
+
+    organization
+        "Dell EMC";
+
+    contact
+        "http://www.dell.com/support";
+
+    description
+        "This module contains a collection of YANG definitions provided
+         by platform for managing Mirroring objects";
+
+    revision 2015-01-31 {
+        description
+        "Initial revision.";
+    }
+
+    typedef mode {
+        type enumeration {
+            enum SPAN {
+                value 1;
+                description
+                    "Local Port Mirroring - Packets can be mirrored only in the local switch";
+            }
+            enum RSPAN {
+                value 2;
+                description
+                    "Remote Port Mirroring - Packets can be mirrored over L2 tunnel
+                     across remote switches";
+            }
+            enum ERSPAN {
+                value 3;
+                description
+                    "Encapsulated Remote Port Mirroring -
+                     Packets can be mirrored over L3 tunnel to remote IP destination";
+            }
+        }
+    }
+
+    grouping rspan-attr {
+
+        description
+            "RSPAN mirror session attributes";
+
+        leaf vlan {
+            mandatory true;
+            type base-cmn:vlan-id;
+            description
+                "Remote SPAN VLAN to be used for mirrored packets";
+        }
+    }
+
+    grouping erspan-attr {
+
+        description
+            "ERSPAN mirror session attributes";		
+	
+       	leaf source-ip {
+    	    mandatory true;
+            type inet:ipv4-address;
+            description
+                "IPv4 source address to be used for ERSPAN tunnel encapsulation";
+        }
+
+        leaf destination-ip {
+            mandatory true;
+            type inet:ipv4-address;
+            description
+                "IPv4 destination address to be used for ERSPAN tunnel encapsulation";
+        }	
+
+        leaf source-mac {
+            mandatory true;
+            type yang:mac-address;
+            description
+                "ERSPAN Tunnel L2 Source MAC Address";
+        }
+
+        leaf dest-mac {
+            mandatory true;
+            type yang:mac-address;
+            description
+                "ERSPAN Tunnel L2 Destination MAC Address";
+        }
+
+        leaf erspan-vlan-id {
+            type base-cmn:vlan-id;
+            description
+                "ERSPAN Tunnel L2 Header VLAN id";
+        } 			
+        leaf ttl {
+            type uint8;
+            description
+                "ERSPAN Tunnel header TTL value";
+        }
+		
+        leaf dscp {
+            type uint8;
+            description
+            "ERSPAN Tunnel header DSCP";
+        }
+		
+        leaf gre-protocol-type{
+            type uint16;
+            description "ERSPAN GRE protocol id";
+        } 		
+    }
+
+    list entry {
+
+        key "id";
+
+        description
+            "Mirror session attributes which contains all the
+             information related to the mirroring session";
+
+        leaf id {
+            type base-cmn:mirror-id;
+            description
+                "Identifier of the mirror-session";
+        }
+
+        leaf opaque-data {
+            config false;
+            type base-cmn:mirror-opaque-data;
+            description
+                "NPU Mirror opaque data associated with the Mirror session";
+        }
+
+        leaf dst-intf{
+            type base-cmn:logical-ifindex;
+            mandatory true;
+            description
+                "Interface Index which is unique across switch of the
+                 mirror destination interface which is physical";
+	    }
+		
+        list intf{
+            key "src";
+            description
+                "List which contains mapping of the Mirror source interface,
+                 and the direction in which mirroring is enabled";
+
+            leaf src {
+                type base-cmn:logical-ifindex;	
+                mandatory true;
+                description
+                    "Interface Index which is unique across switch of the Physical
+                     Interface that needs to be mirrored";
+            }
+
+            leaf direction {
+                mandatory true;
+                type base-cmn:traffic-path;
+                description
+                	"Direction of packets in source interface which needs
+                	 to be mirrored";
+            }
+        }
+
+        leaf flow-enabled {
+            type boolean;
+            default false;
+            description
+                "If true then existing/new mirroring session will be enabled
+                 as flow-enabled session";
+        }
+	
+        leaf type {
+            mandatory true;
+            type mode;
+            description "Type of the mirroring session";
+   	    }
+   	
+   	    leaf lag-opaque-data {
+            config false;
+            type base-cmn:lag-opaque-data;
+            description
+                "NPU LAG opaque data which will be used as mirror destination
+                 when lag interface is mirror destination";
+        }
+
+        uses rspan-attr {
+            when "../type = RSPAN ";
+            description
+                "When mirror session type is RSPAN include RSPAN mirror session attributes";
+        }
+
+        uses erspan-attr {
+            when "../type = ERSPAN ";
+            description
+                "When mirror session type is ERSPAN include ERSPAN mirror session attributes";
+        }
+    }
+}

--- a/python-inocybe-openswitch/models/base-neighbor.yang
+++ b/python-inocybe-openswitch/models/base-neighbor.yang
@@ -1,0 +1,142 @@
+module base-neighbor {
+
+    namespace "http://www.dellemc.com/networking/os10/dell-base-neighbor";
+    prefix "base-neighbor";
+
+    import base-common {
+        prefix "base-cmn";
+    }
+
+    import ietf-interfaces {
+        prefix "if";
+    }
+
+    import base-routing {
+        prefix "base-route";
+    }
+    organization
+        "Dell EMC";
+
+    contact
+        "http://www.dell.com/support";
+
+    description
+        "This module contains a collection of YANG definitions for
+        managing configuration and operational data for Neighbor Object";
+
+    revision 2018-07-03 {
+        description
+            "This revision replaces the interface name with list of interface names in the neighbor flush RPC.";
+        reference "Network Platform Abstraction";
+    }
+    revision 2018-01-31 {
+        description
+            "This revision adds the IP prefix in the neighbor flush RPC.";
+        reference "Network Platform Abstraction";
+    }
+    revision 2017-10-16 {
+        description
+            "This revision adds the auto neighbor refresh configuration.";
+        reference "Network Platform Abstraction";
+    }
+    revision 2017-10-09 {
+        description
+            "This revision adds the vrf-name in the flush RPC.";
+        reference "Network Platform Abstraction";
+    }
+
+    revision 2017-03-13 {
+        description
+            "Clear neighbor functionality";
+        reference "Network Platform Abstraction";
+    }
+
+    revision 2016-11-03 {
+        description
+            "Initial revision.";
+        reference "Network Platform Abstraction";
+    }
+
+    /* 1. Proactive resolution for Route associated NH or apps (PBR, ER-SPAN) desired NH.
+       2. To program blackhole (drop) or forward entry in the NPU */
+    augment "/base-route:obj/base-route:nbr" {
+        leaf phy_ifindex {
+            type base-cmn:logical-ifindex;
+            description "Incase of VLAN IP routing, this holds the physical interface through which the MAC is learnt.";
+        }
+    }
+
+    /* To flush the Nbr entries on admin down */
+    augment "/if:interfaces-state/if:interface" {
+        leaf if-index {
+            type base-cmn:logical-ifindex;
+            description "Flush the neighbor entries configured/learnt on this interface";
+        }
+    }
+
+
+    /* For clear arp/neighbor support */
+    rpc flush {
+     description "Flush the Neighbor entries for given input per Interface or AF or neighbor address/prefix";
+     input {
+
+       leaf vrf-id {
+            type uint32;
+            default 0;
+            description "VRF ID";
+            status obsolete;
+       }
+
+       leaf vrf-name {
+           mandatory true;
+           type string;
+           description "VRF device name";
+       }
+
+       leaf af {
+            type base-cmn:af-type;
+            /* Default Address family - IPv4 (supports both IPv4 and IPv6) */
+            default "inet";
+            description "Address Family of the Neighbor entries to be cleared";
+       }
+
+        /* To flush the Neighbor entries on list of interface names. */
+       leaf-list ifname {
+            type string;
+            description "Flush the Neighbor entries configured/learnt on list of interfaces.";
+       }
+
+       leaf ip {
+            type inet:ip-address;
+            description "Neighbor address/prefix to be flushed.
+               Prefix & prefix-len are specified to flush all neighbors in that subnet.";
+       }
+
+       leaf prefix-len {
+            type uint32;
+            description "Prefix length of neighbors in the subnet to be flushed.";
+       }
+     }
+    }
+
+    list auto-nbr-refresh {
+        key "vrf-name af";
+        description "This controls whether or not the auto neighbor refresh is enabled
+            for the stale neighbor.";
+
+        leaf vrf-name {
+            type string;
+            description "VRF device name";
+        }
+        leaf af {
+            type base-cmn:af-type;
+            description "Address Family";
+        }
+        leaf enable {
+            type boolean;
+            default true;
+            description "This set to true to enable auto neighbor refresh and false otherwise.";
+        }
+    }
+
+}

--- a/python-inocybe-openswitch/models/base-packet.yang
+++ b/python-inocybe-openswitch/models/base-packet.yang
@@ -1,0 +1,317 @@
+module base-packet {
+
+    namespace "http://www.dellemc.com/networking/os10/dell-base-packet";
+    prefix "base-packet";
+
+    import base-common {
+        prefix "base-cmn";
+    }
+
+    import ietf-yang-types {
+        prefix yang;
+    }
+    import ietf-inet-types {
+        prefix inet;
+    }
+
+    organization
+        "Dell EMC";
+
+    contact
+    "http://www.dell.com/support";
+
+    description
+        "This module contains a collection of YANG definitions provided
+         by platform to manage control packet handling";
+
+    revision 2016-03-23 {
+        description
+            "Initial revision";
+    }
+
+    typedef packet-match-type {
+        description "Enumeration of all possible packet fields that can be
+                     used to match packets.";
+
+        type enumeration {
+
+            enum SRC_MAC {
+                value 1;
+                description "Match based on Src MAC Address";
+            }
+
+            enum DST_MAC {
+                value 2;
+                description "Match based on Dst MAC Address";
+            }
+
+            enum SRC_IPV6 {
+                value 3;
+                description "Match based on Src IPv6 Address";
+            }
+
+            enum DST_IPV6 {
+                value 4;
+                description "Match based on Dst IPv6 Address";
+            }
+
+            enum SRC_IP {
+                value 5;
+                description "Match based on Src IPv4 Address";
+            }
+
+            enum DST_IP {
+                value 6;
+                description "Match based on Dst IPv4 Address";
+            }
+
+            enum IN_PORTS {
+                value 7;
+                description "Match packets incoming on any of the specified list of Ports";
+            }
+
+            enum OUT_PORTS {
+                value 8;
+                description "Match packets outgoing on any of the specified list of Ports";
+            }
+
+            enum OUTER_VLAN_ID {
+                value 9;
+                description "Match based on Outer Vlan-Id";
+            }
+
+            enum INNER_VLAN_ID {
+                value 10;
+                description "Match based on Inner Vlan-Id";
+            }
+
+            enum ETHER_TYPE {
+                value 11;
+                description "Match based on EtherType";
+            }
+
+            enum IP_PROTOCOL {
+                value 12;
+                description "Match based on IP Protocol";
+            }
+
+            enum HOSTIF_TRAP_ID {
+                value 13;
+                description "Match based on Host Intf Trap Id";
+            }
+
+            enum HOSTIF_USER_TRAP_ID {
+                value 14;
+                description "Match based on Host Intf User Trap Id";
+            }
+
+            enum OFFSET {
+                value 15;
+                description "Match based on Packet offset";
+            }
+        }
+    }
+
+    typedef packet-direction-type {
+            description "Match based on packet direction";
+
+        type enumeration {
+            enum DIR_IN {
+                value 1;
+                description "Match on Ingress Packet";
+            }
+
+            enum DIR_OUT {
+                value 2;
+                description "Match on Egress Packet";
+            }
+        }
+    }
+
+    typedef packet-action-type {
+        description "Enumeration of packet actions";
+
+        type enumeration {
+
+            enum REDIRECT-IF {
+              value 1;
+                description "Redirect the packet to a specified interface";
+            }
+
+            enum REDIRECT-SOCK {
+              value 2;
+                description "Redirect the packet to a specified socket. Not a valid action for DIR_OUT";
+            }
+
+            enum COPY-TO-SOCK {
+              value 3;
+                description "Copy the packet to a specified socket. Not a valid action for DIR_OUT";
+            }
+        }
+    }
+
+    grouping offset-match {
+        description "Match up to twelve bytes from a specified offset.
+                     Match start from the offset-pos for the next len bytes";
+
+        leaf data {
+           type binary {
+               length "12";
+           }
+        }
+
+        leaf mask {
+           type binary {
+               length "12";
+           }
+        }
+
+        leaf len {
+            type uint32;
+        }
+
+        leaf offset-pos {
+            type uint32;
+        }
+    }
+
+    grouping match-parameters {
+        description "Specify the match-parameter. Only ONE field of packet-match-type must be
+                     filled as part of one match criteria.
+                     For e.g., if match-type is SRC_IPV6, then provide the leaf-attribute <ipv6>
+                     Similarly if match-type is OUTER_VLAN_ID or TRAP_ID, then provide vlan-id or
+                     trap-id value in leaf-attribute <data>";
+
+        leaf type {
+            type packet-match-type;
+        }
+
+        leaf ipv4 {
+            type inet:ipv4-address;
+        }
+
+        leaf ipv6 {
+            type inet:ipv6-address;
+        }
+
+        leaf mac-addr {
+            type yang:mac-address;
+        }
+
+        leaf-list ports {
+            type base-cmn:logical-ifindex;
+        }
+
+        leaf data {
+            type uint64;
+        }
+
+        container offset-value {
+            when "../type = OFFSET";
+            uses offset-match;
+        }
+    }
+
+    grouping action-parameters {
+
+        leaf type {
+            type packet-action-type;
+        }
+
+        leaf redirect-if {
+            type base-cmn:logical-ifindex;
+        }
+
+        container socket-address {
+            description
+                "Address that applications need to open UDP socket to receive matched packets
+                 Applications must provide this while creating the rule with socket action";
+
+            leaf ip {
+                mandatory true;
+                type inet:ipv4-address;
+            }
+
+            leaf udp-port {
+                mandatory true;
+                type uint16;
+            }
+        }
+    }
+
+    list rule {
+        description "List of control packet software filter entries. Every rule is intended to be matched
+                     and corresponding action taken. Currently, there is no priority matching or any conflict
+                     resolution. Each rule can have a list of match-parameters and a list of actions.
+                     For e.g.:
+                     <rule1> <match-1><match-2> <action-1>, then both match-1 AND 2 must match for action-1.
+                     If you need an OR operation then create rules as below:
+                     <rule1> <match-1> <action-1>
+                     <rule2> <match-1> <atcion-1>
+
+                     Default packet action is:
+                      Ingress -> Forward packet to the kernel tap interface mapped to front-panel npu port
+                      Egress  -> Forward packet to the npu port corresponding to the mapped tap interface
+
+                     If the matched-rule has only action as COPY-TO-SOCK, then default action shall ALSO be applied.
+                     In all other cases, the default action is NOT taken";
+
+        key "id";
+
+        leaf id {
+            description  "Id to uniquely identify a packet match criteria.
+                          A unique integer value shall be returned to the application and can
+                          be used as the key for all further get and delete actions";
+            type uint32;
+        }
+
+        leaf direction {
+            description  "Rule to be applied on either Ingress or Egress packets";
+
+            type packet-direction-type;
+            default DIR_IN;
+        }
+
+        list match {
+            description  "Match-filter list";
+
+            key "type";
+            min-elements "1";
+            uses match-parameters;
+        }
+
+        list action {
+            description "List of actions";
+
+            key "type";
+            uses action-parameters;
+        }
+
+        leaf stop {
+            description  "Stop processing further rules";
+
+            type boolean;
+            default true;
+        }
+    }
+
+    container statistics {
+        description "Collection of control packet statistics objects.";
+
+        leaf sflow-pkts {
+            description "Number of SFLOW sampled packets lifted to CPU";
+            type yang:counter64;
+        }
+
+        leaf in-pkts {
+            description "Number of ingressed packets received by packet-IO";
+            type yang:counter64;
+        }
+
+        leaf out-pkts {
+            description "Number of egressed packets trasmitted by packet-IO";
+            type yang:counter64;
+        }
+    }
+
+}

--- a/python-inocybe-openswitch/models/base-pas.yang
+++ b/python-inocybe-openswitch/models/base-pas.yang
@@ -1,0 +1,442 @@
+module base-pas {
+
+  namespace "http://www.dellemc.com/networking/os10/dell-base-pas";
+
+  prefix "base-pas";
+
+  import base-platform-common {
+    prefix "platform";
+  }
+
+  organization "Dell EMC";
+
+  contact "http://www.dell.com/support";
+
+  description "Configuration and operational data for OS10 Platform Abtraction Service";
+
+  revision 2015-04-03 {
+    description "Initial revision.";
+  }
+
+  revision 2017-11-09 {
+    description "Input Power Monitor Support";
+  }
+
+  revision 2017-12-04 {
+    description "new object for PAS platform fault";
+  }
+
+  //PAS Notify subcategory
+
+  list ready {
+    description "PAS status notification";
+
+    key "slot";
+
+    leaf slot {
+      description "Slot number";
+      type uint8;
+    }
+
+    uses platform:pas_notify;
+  }
+
+  // PAS platform-fault subcategory
+
+  container platform-fault {
+      description "platform fault notification";
+
+      uses platform:pas_fault;
+  }
+
+  // comm-dev subcategory
+
+  container comm-dev {
+      description "Attributes of comm-dev component";
+
+      uses platform:comm-dev;
+  }
+
+  // host-system subcategory
+
+  container host-system {
+      description "Attributes of host-system component";
+
+      uses platform:host-system;
+  }
+
+
+
+  // Chassis subcategory
+
+  container chassis {
+    description "Attributes of a chassis";
+
+    uses platform:chassis;
+  }
+
+  // Entity subcategory
+
+  list entity {
+    description "Attributes of an entity (FRU)";
+
+    key "entity-type slot";
+
+    leaf entity-type {
+        description "Entity type";
+        type platform:entity-type;
+    }
+
+    leaf slot {
+        description "Entity slot";
+        type uint8;
+    }
+
+    uses platform:entity;
+  }
+
+  // PSU subcategory
+
+  list psu {
+    description "Attributes of a power supply";
+
+    key "slot";
+
+    leaf slot {
+        description "PSU slot";
+        type uint8;
+    }
+
+    uses platform:psu;
+  }
+
+  // Fan tray subcategory
+
+  list fan-tray {
+    description "Attributes of a fan tray";
+
+    key "slot";
+
+    leaf slot {
+        description "Fan tray slot";
+        type uint8;
+    }
+
+    uses platform:fan-tray;
+  }
+
+  // Card subcategory
+
+  list card {
+    description "Attributes of a card";
+
+    key "slot";
+
+    leaf slot {
+        description "Card slot";
+        type uint8;
+    }
+
+    uses platform:card;
+  }
+
+  // Fan subcategory
+
+  list fan {
+    description "Attributes of a (PSU or fan tray) fan";
+
+    key "entity-type slot fan-index";
+
+    leaf entity-type {
+        description "Entity type";
+        type platform:entity-type;
+    }
+
+    leaf slot {
+        description "Entity slot";
+        type uint8;
+    }
+
+    leaf fan-index {
+        description "Index of fan on entity";
+        type uint8;
+    }
+
+    uses platform:fan;
+  }
+
+  // LED subcategory
+
+  list led {
+    description "Attributes of an LED";
+
+    key "entity-type slot name";
+
+    leaf entity-type {
+        description "Entity type";
+        type platform:entity-type;
+    }
+
+    leaf slot {
+        description "Entity slot";
+        type uint8;
+    }
+
+    leaf name {
+      description "Printable name for LED";
+      type string;
+    }
+
+    uses platform:led;
+  }
+
+  // Display subcategory
+
+  list display {
+    description "Attributes of a text message display";
+
+    key "entity-type slot name";
+
+    leaf entity-type {
+        description "Entity type";
+        type platform:entity-type;
+    }
+
+    leaf slot {
+        description "Entity slot";
+        type uint8;
+    }
+
+    leaf name {
+      description "Printable name for display";
+      type string;
+    }
+
+    uses platform:display;
+  }
+
+  // Temperature sensor subcategory
+
+  list temperature {
+    description "Attributes of a temperature sensor";
+
+    key "entity-type slot name";
+
+    leaf entity-type {
+        description "Entity type";
+        type platform:entity-type;
+    }
+
+    leaf slot {
+        description "Entity slot";
+        type uint8;
+    }
+
+    leaf name {
+      description "Printable name for sensor";
+      type string;
+    }
+
+    uses platform:temperature;
+  }
+
+  // Temperature sensor range threshold subcategory
+
+  list temp_threshold {
+    description "Attributes of a temperature sensor threshold";
+
+    key "entity-type slot name threshold-index";
+
+    leaf entity-type {
+        description "Entity type";
+        type platform:entity-type;
+    }
+
+    leaf slot {
+        description "Entity slot";
+        type uint8;
+    }
+
+    leaf name {
+      description "Printable name for sensor";
+      type string;
+    }
+
+    leaf threshold-index {
+        description "Index of threshold for sensor";
+        type uint8;
+    }
+
+    uses platform:temp_threshold;
+  }
+
+  // Power-monitor subcategory
+
+  list power-monitor {
+    description "Attributes of an Input Power Monitor which is the total power consumed (including PSU loss) by the system";
+
+    key "entity-type slot monitor-index";
+
+    leaf entity-type {
+        description "Entity type";
+        type platform:entity-type;
+    }
+
+    leaf slot {
+        description "Entity slot";
+        type uint8;
+    }
+
+    leaf monitor-index {
+        description "Index of power monitor chip on entity";
+        type uint8;
+    }
+
+    uses platform:power-monitor;
+  }
+
+  // PLD subcategory
+
+  list pld {
+    description "Attributes of a programmable logic device (PLD)";
+
+    key "entity-type slot name";
+
+    leaf entity-type {
+        description "Entity type";
+        type platform:entity-type;
+    }
+
+    leaf slot {
+        description "Entity slot";
+        type uint8;
+    }
+
+    leaf name {
+      description "Printable name for PLD";
+      type string;
+    }
+
+    uses platform:pld;
+  }
+
+  // Port module subcategory
+
+  list port-module {
+    description "Attributes of a linecard port module";
+
+    key "slot port-module-slot";
+
+    leaf slot {
+        description "Card slot";
+        type uint8;
+    }
+
+    leaf port-module-slot {
+        description "Slot of port module on card";
+        type uint8;
+    }
+
+    uses platform:port-module;
+  }
+
+  /* PAS Media releated configuration */
+
+  list media-config {
+    description "PAS media configuration.";
+
+    key "node-id slot";
+
+    leaf node-id {
+      description "Node Id (Chassis id / stackId)";
+      type uint32;
+    }
+
+    leaf slot {
+      description "Card slot number";
+      type uint32;
+    }
+
+    uses platform:pas-media-config;
+  }
+
+  // Optical media adapter subcategory
+
+  list media {
+    description "Attributes of an optical media adapter";
+
+    key "slot port-module-slot port";
+
+    leaf slot {
+        description "Card slot";
+        type uint8;
+    }
+
+    leaf port-module-slot {
+        description "Slot of port module on card";
+        type uint8;
+    }
+
+    leaf port {
+        description "Port on port module";
+        type uint8;
+    }
+
+    uses platform:media;
+  }
+
+  // Optical media adapter channel subcategory
+
+  list media-channel {
+    description "Attributes of a channel of an optical media adapter";
+
+    key "slot port-module-slot port channel";
+
+    leaf slot {
+        description "Card slot";
+        type uint8;
+    }
+
+    leaf port-module-slot {
+        description "Slot of port module on card";
+        type uint8;
+    }
+
+    leaf port {
+        description "Port on port module";
+        type uint8;
+    }
+
+    leaf channel {
+        description "Channel of given port";
+        type uint8;
+    }
+
+    uses platform:media-channel;
+  }
+
+  // PHY subcategory
+
+  list phy {
+    description "Attributes of a port PHY";
+
+    key "slot port-module-slot port";
+
+    leaf slot {
+        description "Card slot";
+        type uint8;
+    }
+
+    leaf port-module-slot {
+        description "Slot of port module on card";
+        type uint8;
+    }
+
+    leaf port {
+        description "Port on port module";
+        type uint8;
+    }
+
+    uses platform:phy;
+  }
+}

--- a/python-inocybe-openswitch/models/base-port-group.yang
+++ b/python-inocybe-openswitch/models/base-port-group.yang
@@ -1,0 +1,54 @@
+module base-port-group {
+    namespace "http://www.dellemc.com/networking/os10/dell-base-port-group";
+    prefix "base-pg";
+
+    import port-group { prefix "pg"; }
+
+    organization "Dell EMC";
+    contact "http://www.dell.com/support";
+
+    description "This model contains Dell EMC specific port-group defintion and its attributes.";
+
+    revision "2018-04-05" {
+        description "Augmenting hybrid group config and state object.";
+        reference "Network Platform Abstraction";
+    }
+
+    revision "2016-11-22" {
+        description "Initial version.";
+    }
+
+    augment "/pg:port-groups/pg:port-group" {
+
+    }
+
+    augment "/pg:port-groups/pg:hybrid-group" {
+
+    }
+
+    augment "/pg:port-groups-state/pg:port-group-state" {
+        leaf-list hwport-list {
+            type uint32;
+            description "List of hardware ports belonging to this port-group";
+        }
+
+        leaf-list front-panel-port {
+            type uint32;
+            description "list of the front panel port Ids associated with this port-group.";
+        }
+    }
+
+
+    augment "/pg:port-groups-state/pg:hybrid-group-state" {
+        leaf-list hwport-list {
+            type uint32;
+            description "List of hardware ports belonging to this port-group";
+        }
+
+        leaf-list front-panel-port {
+            type uint32;
+            description "list of the front panel port id's associated with this port-group.";
+        }
+    }
+
+}

--- a/python-inocybe-openswitch/models/base-qos.yang
+++ b/python-inocybe-openswitch/models/base-qos.yang
@@ -1,0 +1,2233 @@
+module base-qos {
+
+    namespace "http://www.dellemc.com/networking/os10/dell-base-qos";
+    prefix "base-qos";
+
+    import base-common {
+        prefix "base-cmn";
+    }
+    import ietf-yang-types {
+        prefix "yang";
+    }
+    import ietf-inet-types {
+        prefix "inet";
+    }
+    organization
+        "Dell EMC";
+
+    contact
+        "http://www.dell.com/support";
+
+    description
+        "This module contains a collection of YANG definitions for QoS objects
+
+         Copyright (c) 2015-2016 by Dell EMC,
+         All rights reserved.";
+
+    revision 2018-01-30 {
+        description
+            "Add ECN color-blind threshold;
+             Allow separate handling of ECT and non-ECT traffic";
+    }
+
+    revision 2017-12-01 {
+        description
+            "Add range to Meter, WRED-profile, Scheduler-profile, Map,
+             Buffer Pool and Buffer Profile Id.";
+    }
+
+    revision 2016-03-31 {
+        description
+            "Add Buffer Management.";
+    }
+
+    revision 2015-02-03 {
+        description
+            "Initial revision.";
+    }
+
+    typedef meter-type {
+        type enumeration {
+            enum PACKET {
+              value 1;
+            }
+            enum BYTE {
+              value 2;
+            }
+        }
+    }
+
+    typedef policer-action {
+        type enumeration {
+            enum FORWARD {
+                value 1;
+            }
+            enum DROP {
+                value 2;
+            }
+        }
+    }
+
+    typedef queue-type {
+        type enumeration {
+            enum NONE {
+                value 1;
+                description "hardware queue for both unicast and multicast traffic";
+            }
+            enum UCAST {
+                value 2;
+                description "hardware unicast queue";
+            }
+            enum MULTICAST {
+                value 3;
+                description "hardware multicast queue";
+            }
+        }
+    }
+
+    typedef scheduling-type {
+        type enumeration {
+            enum SP {
+                value "1";
+                description "Strict Priority";
+            }
+            enum WRR {
+                value "2";
+                description "Weighted Round-Robin";
+            }
+            enum WDRR {
+                value "3";
+                description "Weighted Deficit RR";
+            }
+        }
+    }
+
+    typedef packet-color {
+        type enumeration {
+            enum GREEN {
+                value "1";
+                description "Green";
+            }
+            enum YELLOW {
+                value "2";
+                description "Yellow";
+            }
+            enum RED {
+                value "3";
+                description "Red";
+            }
+        }
+    }
+
+    typedef meter-mode {
+        type enumeration {
+            enum Sr_TCM {
+                value 1;
+                description "Single Rate Tri Color Meter";
+            }
+            enum Tr_TCM {
+                value 2;
+                description "Two Rate Tri Color Meter";
+            }
+            enum Sr_TWO_COLOR {
+                value 3;
+                description "Single Rate Two Color Meter
+                            [Committed Rate, Committed Burst,
+                            green-packet-action and red-packet-action are used]";
+            }
+            enum STORM_CONTROL {
+                value 4;
+                description "Storm Control Meter [Single Rate Two Color mode]";
+            }
+        }
+    }
+
+    typedef meter-color-source {
+        type enumeration {
+            enum BLIND {
+                value 1;
+            }
+
+            enum AWARE {
+                value 2;
+            }
+        }
+    }
+
+    typedef flow-control {
+        type enumeration {
+            enum DISABLE {
+                value 1;
+            }
+
+            enum TX-ONLY {
+                value 2;
+            }
+
+            enum RX-ONLY {
+                value 3;
+            }
+
+            enum BOTH-ENABLE {
+                value 4;
+            }
+        }
+    }
+
+    typedef policer-stat-type {
+        type enumeration {
+            enum PACKETS {
+                value 1;
+            }
+
+            enum BYTES {
+                value 2;
+            }
+
+            enum GREEN_PACKETS {
+                value 3;
+            }
+
+            enum GREEN_BYTES {
+                value 4;
+            }
+
+            enum YELLOW_PACKETS {
+                value 5;
+            }
+
+            enum YELLOW_BYTES {
+                value 6;
+            }
+
+            enum RED_PACKETS {
+                value 7;
+            }
+
+            enum RED_BYTES {
+                value 8;
+            }
+        }
+    }
+
+    typedef buffer-pool-type {
+        type enumeration {
+            enum INGRESS {
+                value 1;
+            }
+            enum EGRESS {
+                value 2;
+            }
+        }
+    }
+
+    typedef buffer-threshold-mode {
+        type enumeration {
+            enum STATIC {
+                value 1;
+            }
+            enum DYNAMIC {
+                value 2;
+            }
+        }
+    }
+
+    typedef ecn-mark-mode {
+        type enumeration {
+            enum NONE {
+                value 0;
+            }
+            enum GREEN {
+                value 1;
+            }
+            enum YELLOW {
+                value 2;
+            }
+            enum RED {
+                value 3;
+            }
+            enum GREEN-YELLOW {
+                value 4;
+            }
+            enum GREEN-RED {
+                value 5;
+            }
+            enum YELLOW-RED {
+                value 6;
+            }
+            enum ALL {
+                value 7;
+            }
+        }
+    }
+
+    list meter{
+        key "id";
+
+        description "This defines a QoS Ingress Meter.";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this Meter belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf id {
+            type base-cmn:base-obj-id-type {
+	            range "1..500";
+            }
+            description "Ingress Meter Id";
+        }
+
+        leaf type {
+            mandatory true;
+            type meter-type;
+            description "meter based on packets or bytes";
+        }
+
+        leaf mode {
+            mandatory true;
+            type meter-mode;
+            description "Single-Rate/Two-Rate Two-Color/Tri-Color Meter";
+        }
+
+        leaf color-source {
+            type meter-color-source;
+            description "Policer color aware or color blind";
+        }
+
+
+        leaf green-packet-action {
+            type policer-action;
+            description "Green packet action";
+        }
+
+        leaf yellow-packet-action {
+            type policer-action;
+            description "Yellow packet action";
+        }
+
+        leaf red-packet-action {
+            type policer-action;
+            description "Red packet action";
+        }
+
+        leaf committed-burst {
+            type uint64;
+            description "Burst size in byte";
+        }
+
+        leaf committed-rate {
+            type uint64;
+            description "Committed Rate in byte-per-second or packets";
+        }
+
+        leaf peak-burst {
+            type uint64;
+            description "Peak burst size in byte";
+        }
+
+        leaf peak-rate {
+            type uint64;
+            description "Peak rate in byte-per-second or packets. Only valid for Two Rate Tri Color Meter";
+        }
+
+        leaf-list stat-list {
+            type policer-stat-type;
+            description "various policer statistics to be collected";
+        }
+
+        leaf packets {
+            type yang:counter64;
+            config false;
+            description "total packet count";
+        }
+
+        leaf bytes {
+            type yang:counter64;
+            config false;
+            description "total byte count";
+        }
+
+        leaf green-packets {
+            type yang:counter64;
+            config false;
+            description "green packet count";
+        }
+
+        leaf green-bytes {
+            type yang:counter64;
+            config false;
+            description "green byte count";
+        }
+
+        leaf yellow-packets {
+            type yang:counter64;
+            config false;
+            description "yellow packet count";
+        }
+
+        leaf yellow-bytes {
+            type yang:counter64;
+            config false;
+            description "yellow byte count";
+        }
+
+        leaf red-packets {
+            type yang:counter64;
+            config false;
+            description "red packet count";
+        }
+
+        leaf red-bytes {
+            type yang:counter64;
+            config false;
+            description "red byte count";
+        }
+
+        leaf data {
+            type base-cmn:qos-meter-opaque-data;
+            config false;
+            description "Internal hardware specific Meter data blob.";
+        }
+
+        leaf-list npu-id-list {
+            type base-cmn:npu-id;
+            description
+                "Optional subset of NPUs on which this Meter needs to be created.
+                 If this attribute is not specified then the Meter is installed
+                 on all NPUs in the Logical switch to which the Meter belongs.";
+        }
+    }
+
+    list wred-profile {
+        key "id";
+
+        description "This defines the WRED profile. The wred profile can be attached
+                     to a port, queue or buffer. Storm control also uses this profile";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this Profile belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf id {
+            type base-cmn:base-obj-id-type {
+	            range "1..500";
+            }
+            description "WRED profile id";
+        }
+
+        leaf green-enable {
+            type boolean;
+            default false;
+            description "Enable/Disable WRED.";
+        }
+
+        leaf green-min-threshold {
+            type uint32;
+            description "Minimum threshold in bytes after which packets will
+                be dropped based on the drop probability";
+        }
+
+        leaf green-max-threshold {
+            type uint32;
+            description "Maximum threshold in bytes after which packets will be
+                tail dropped";
+        }
+
+        leaf green-drop-probability {
+            type uint32 {range "0..100";}
+            default 100;
+            description "Percentage probability with which packets will be
+                dropped when minimum threshold is reached";
+        }
+
+        leaf yellow-enable {
+            type boolean;
+            default false;
+            description "Enable/Disable WRED.";
+        }
+
+        leaf yellow-min-threshold {
+            type uint32;
+            description "Minimum threshold in bytes after which packets will
+                be dropped based on the drop probability";
+        }
+
+        leaf yellow-max-threshold {
+            type uint32;
+            description "Maximum threshold in bytes after which packets will be
+                tail dropped";
+        }
+
+        leaf yellow-drop-probability {
+            type uint32 {range "0..100";}
+            default 100;
+            description "Percentage probability with which packets will be
+                dropped when minimum threshold is reached";
+        }
+
+        leaf red-enable {
+            type boolean;
+            default false;
+            description "Enable/Disable WRED.";
+        }
+
+        leaf red-min-threshold {
+            type uint32;
+            description "Minimum threshold in bytes after which packets will
+                be dropped based on the drop probability";
+        }
+
+        leaf red-max-threshold {
+            type uint32;
+            description "Maximum threshold in bytes after which packets will be
+                tail dropped";
+        }
+
+        leaf red-drop-probability {
+            type uint32 {range "0..100";}
+            default 100;
+            description "Percentage probability with which packets will be
+                dropped when minimum threshold is reached";
+        }
+
+        leaf weight {
+            type uint32 {range "0..15";}
+            default 0;
+            description "The average queue size depends on the previous average
+             as well as the current size of the queue.
+             The Weight indicates the importance of previous average
+             queue length compared to the current queue size.
+             The higher value of the Weight, the more important
+             the previous average queue length. Peak and low in queue
+             length will be smoothed by a high value.
+             Low values of Weight allow the average queue size to stay
+             close to the current queue size.";
+        }
+
+        leaf ecn-enable {
+            status deprecated;
+            default false;
+            type boolean;
+            description "Flag to indicate if ECN generation is enabled on congestion";
+        }
+
+        leaf ecn-mark {
+            type ecn-mark-mode;
+            description "Flag to indicate what type of packets will be ECN-marked
+                during congestion.
+                When Global ECN ECT flag is disabled, both ECT and non-ECT traffic
+                are subject to WRED thresholds.
+                When Global ECN ECT is enabled, non-ECT traffic will be subject to
+                WRED thresholds, while ECT traffic is subject to ECN-thresholds.";
+        }
+
+        container ecn-green {
+            description "Separate threshold for ECT-traffic";
+            uses thresholds;
+        }
+
+        container ecn-yellow {
+            description "Separate threshold for ECT-traffic";
+            uses thresholds;
+        }
+
+        container ecn-red {
+            description "Separate threshold for ECT-traffic";
+            uses thresholds;
+        }
+
+        container ecn-color-unaware {
+            description "Separate threshold for ECT-traffic";
+            uses thresholds;
+        }
+
+        leaf-list npu-id-list {
+            type base-cmn:npu-id;
+            description
+                "Optional subset of NPUs on which this Profile needs to be created.
+                 If this attribute is not specified then the Profile is created
+                 on all NPUs in the Logical switch to which the Profile belongs.";
+        }
+    }
+
+    list queue {
+        key "port-id queue-number type";
+
+        description "This defines attributes of a QoS queue.
+                     QoS queues are initialized by SAI automatically.
+                     User can reprogram other queue attributes.";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this queue id belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf port-id {
+            mandatory true;
+            type base-cmn:logical-ifindex;
+            description "Physical port to which this queue belongs.";
+        }
+
+        leaf type {
+            mandatory true;
+            type queue-type;
+            description "Queue type";
+        }
+
+        leaf queue-number {
+            mandatory true;
+            type uint32;
+            description "locally unique id within a port and a specific queue type";
+        }
+
+        leaf id {
+            type base-cmn:base-obj-id-type;
+            config false;
+            description "unique queue id across the whole switch assigned to the queue";
+        }
+
+        leaf parent {
+            mandatory true;
+            type base-cmn:base-obj-id-type;
+            description "parent scheduler group node in case of Hierarchical QoS support";
+        }
+
+        leaf wred-id {
+            type base-cmn:base-obj-id-type;
+            description "WRED profile id";
+        }
+
+        leaf buffer-profile-id {
+            type base-cmn:base-obj-id-type;
+            description "buffer profile id";
+        }
+
+        leaf scheduler-profile-id {
+            type base-cmn:base-obj-id-type;
+            description "Scheduler profile Id associated to this queue";
+        }
+
+        leaf data {
+            type base-cmn:qos-queue-opaque-data;
+            config false;
+            description "Internal hardware specific Queue data blob.";
+        }
+
+        leaf-list mmu-index-list {
+            config false;
+            type uint32;
+            description "In multi-MMU (Memory Management Unit) system,
+                         1-based indexes of the MMUs where the queue is present.";
+        }
+    }
+
+    list queue-stat {
+        key "port-id type queue-number mmu-index";
+
+        description "This defines QoS queue counter statistics.";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this queue id belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf port-id {
+            type base-cmn:logical-ifindex;
+            description "Physical port to which this queue belongs.";
+        }
+
+        leaf type {
+            type queue-type;
+            description "Queue type";
+        }
+
+        leaf queue-number {
+            type uint32;
+            description "locally unique id within a port and a specific queue type";
+        }
+
+        leaf mmu-index {
+            type uint32;
+            default 0;
+            description "In multi-MMU system, if non-zero MMU-index is
+                provided, statistics on the specific MMU will be reported.";
+        }
+
+        leaf packets {
+            type yang:counter64;
+            description "tx packets count";
+        }
+
+        leaf bytes {
+            type yang:counter64;
+            description "tx bytes count";
+        }
+
+        leaf dropped-packets {
+            type yang:counter64;
+            description "dropped packets count";
+        }
+
+        leaf dropped-bytes {
+            type yang:counter64;
+            description "dropped bytes count";
+        }
+
+        leaf green-packets {
+            type yang:counter64;
+            description "green color tx packets count";
+        }
+
+        leaf green-bytes {
+            type yang:counter64;
+            description "green color tx bytes count";
+        }
+
+        leaf green-dropped-packets {
+            type yang:counter64;
+            description "green color dropped packets count";
+        }
+
+        leaf green-dropped-bytes {
+            type yang:counter64;
+            description "green color dropped bytes count";
+        }
+
+        leaf yellow-packets {
+            type yang:counter64;
+            description "yellow color tx packets count";
+        }
+
+        leaf yellow-bytes {
+            type yang:counter64;
+            description "yellow color tx bytes count";
+        }
+
+        leaf yellow-dropped-packets {
+            type yang:counter64;
+            description "yellow color dropped packets count";
+        }
+
+        leaf yellow-dropped-bytes {
+            type yang:counter64;
+            description "yellow color dropped bytes count";
+        }
+
+        leaf red-packets {
+            type yang:counter64;
+            description "red color tx packets count";
+        }
+
+        leaf red-bytes {
+            type yang:counter64;
+            description "red color tx bytes count";
+        }
+
+        leaf red-dropped-packets {
+            type yang:counter64;
+            description "red color dropped packets count";
+        }
+
+        leaf red-dropped-bytes {
+            type yang:counter64;
+            description "red color dropped bytes count";
+        }
+
+        uses wred-stat;
+
+        uses wred-ecn-stat;
+
+        uses buffer-stat;
+
+    }
+
+
+
+    list scheduler-profile {
+        key "id";
+
+        description "This defines attributes of a QoS scheduler profile.
+                     QoS scheduler profile can be attached to a queue or
+                     a queue group.";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this scheduler profile id belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf id {
+            type base-cmn:base-obj-id-type {
+	            range "1..2000";
+            }
+            description "Scheduler profile Id";
+        }
+
+        leaf algorithm {
+            type scheduling-type;
+            default WDRR;
+            description "Strict Priority or DWRR scheduling algorithm";
+        }
+
+        leaf weight {
+            type uint32;
+            description "Scheduling weight";
+        }
+
+        leaf meter-type {
+            type meter-type;
+            description "meter type: packets or bytes";
+        }
+
+        leaf min-rate {
+            type uint64;
+            description "Guaranteed bandwidth shape rate [bytes/sec or PPS]";
+        }
+
+        leaf min-burst {
+            type uint64;
+            description "Guaranteed burst for bandwidth shape rate [Bytes or Packets]";
+        }
+
+        leaf max-rate {
+            type uint64;
+            description "Maximum bandwidth shape rate [bytes/sec or PPS]";
+        }
+
+        leaf max-burst {
+            type uint64;
+            description "Maximum burst for bandwidth shape rate [Bytes or Packets]";
+        }
+
+        leaf-list npu-id-list {
+            type base-cmn:npu-id;
+            description
+                "Optional subset of NPUs on which this Profile needs to be created.
+                 If this attribute is not specified then the Profile is created
+                 on all NPUs in the Logical switch to which the Profile belongs.";
+        }
+        leaf name {
+            type string {
+                length 32;
+            }
+            description "Optional user-provided name for the scheduler profile";
+        }
+    }
+
+    list scheduler-group {
+        key "id";
+
+        description "This defines attributes of a QoS scheduler group.
+                     QoS scheduler group consists of a number of queues or
+                     child scheduler groups. When a scheduler-group is created,
+                     port-id and level must be specified at creation.";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this scheduler group id belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf id {
+            type base-cmn:base-obj-id-type;
+            description "Scheduler group Id";
+        }
+
+        leaf child_count {
+            type uint32;
+            config false;
+            description "Number of queues/child groups added to the scheduler group.";
+        }
+
+        leaf-list child-list {
+            type base-cmn:base-obj-id-type;
+            config false;
+            description "Child scheduler group id list or queue id list added to this scheduler group";
+        }
+
+        leaf port-id {
+            mandatory true;
+            type  base-cmn:logical-ifindex;
+            description "port id to which the scheduler group belongs";
+        }
+
+        leaf level {
+            mandatory true;
+            type uint32;
+            description "scheduler group level.
+                         Level 0 scheduler group is the Port-level scheduler group;
+                         Level (MAX_NUMBER_OF_SCHEDULER_GROUP_HIERACHY_LEVELS - 1) scheduler group
+                         consists of Queue ids in the child-list.
+                         Other values beyond this range are invalid.";
+        }
+
+        leaf max-child {
+            mandatory true;
+            type uint32;
+            description "Maximum number of child on group";
+        }
+
+        leaf scheduler-profile-id {
+            mandatory true;
+            type base-cmn:base-obj-id-type;
+            description "scheduler profile id associated to this scheduler group";
+        }
+
+        leaf parent {
+            mandatory true;
+            type base-cmn:base-obj-id-type;
+            description "Scheduler group parent node. If the level is 0, the parent-node is the port.";
+        }
+    }
+
+    list dot1p-to-tc-map {
+        key "id";
+        description "This defines a map which maps the incoming dot1p values
+               to traffic-classes. A valid dot1p-to-tc-map id can then be
+               applied to a port.";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this interface belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+
+        leaf id {
+            type base-cmn:base-obj-id-type {
+	            range "1..127";
+            }
+            description "Map identifier.";
+        }
+
+        leaf name {
+            type string {
+                length 32;
+            }
+            description "Optional user-provided name for the map";
+        }
+
+        list entry {
+            key "dot1p";
+            leaf dot1p {
+                type base-cmn:dot1p;
+                description "incoming dot1p value";
+            }
+
+            leaf tc {
+                type base-cmn:traffic-class;
+                description "Traffic class that given dot1p is mapped to";
+            }
+        }
+    }
+
+    list dscp-to-tc-map {
+        key "id";
+        description "This defines a map which maps the incoming dscp values
+                     to traffic-classes. A valid dscp-to-tc-map id can then be
+                     applied to a port.";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this interface belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf id {
+            type base-cmn:base-obj-id-type {
+                range "1..127";
+            }
+
+            description "Map identifier.";
+        }
+
+        leaf name {
+            type string {
+                length 32;
+            }
+            description "Optional user-provided name for the map";
+        }
+
+        list entry {
+            key "dscp";
+            leaf dscp {
+                type inet:dscp;
+                description "incoming dscp value";
+            }
+
+            leaf tc {
+                type base-cmn:traffic-class;
+                description "Traffic class that given dscp is mapped to";
+            }
+        }
+    }
+
+    list dot1p-to-color-map {
+        key "id";
+        description "This defines a map which marks a packet with a different color
+                     by its incoming dot1p value.
+                     A valid dot1p-to-color-map id can then be applied to a port.";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this interface belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf id {
+            type base-cmn:base-obj-id-type {
+	            range "1..127";
+            }
+            description "Map identifier.";
+        }
+
+        leaf name {
+            type string {
+                length 32;
+            }
+            description "Optional user-provided name for the map";
+        }
+
+        list entry {
+            key "dot1p";
+            leaf dot1p {
+                type base-cmn:dot1p;
+                description "incoming dot1p value";
+            }
+
+            leaf color {
+                type packet-color;
+                description "Packet color that given dot1p is mapped to";
+            }
+        }
+    }
+
+    list dot1p-to-tc-color-map {
+        status deprecated;
+
+        key "id";
+        description "This defines a map which maps the incoming dot1p values
+                     to traffic-classes and marks a packet with a different color
+                     by its incoming dot1p value.
+                     A valid dot1p-to-tc-color-map id can then be applied to a port.";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this interface belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf id {
+            type base-cmn:base-obj-id-type {
+	            range "1..127";
+            }
+            description "Map identifier.";
+        }
+
+        leaf name {
+            type string {
+                length 32;
+            }
+            description "Optional user-provided name for the map";
+        }
+
+        list entry {
+            key "dot1p";
+            leaf dot1p {
+                type base-cmn:dot1p;
+                description "incoming dot1p value";
+            }
+
+            leaf tc {
+                type base-cmn:traffic-class;
+                description "Traffic class that given dot1p is mapped to";
+            }
+
+            leaf color {
+                type packet-color;
+                description "Packet color that given dot1p is mapped to";
+            }
+        }
+    }
+
+    list dscp-to-color-map {
+        key "id";
+        description "This defines a map which marks a packet with a different color
+                     by its incoming dscp value.
+                     A valid dscp-to-color-map id can then be applied to a port.";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this interface belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf id {
+            type base-cmn:base-obj-id-type {
+	            range "1..127";
+            }
+            description "Map identifier.";
+        }
+
+        leaf name {
+            type string {
+                length 32;
+            }
+            description "Optional user-provided name for the map";
+        }
+
+        list entry {
+            key "dscp";
+            leaf dscp {
+                type inet:dscp;
+                description "incoming dscp value";
+            }
+
+            leaf color {
+                type packet-color;
+                description "Packet color that given dscp is mapped to";
+            }
+        }
+    }
+
+    list dscp-to-tc-color-map {
+        status deprecated;
+
+        key "id";
+        description "This defines a map which maps the incoming dscp values
+                     to traffic-classes and  marks a packet with a different color
+                     by its incoming dscp value.
+                     A valid dscp-to-tc-color-map id can then be applied to a port.";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this interface belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf id {
+            type base-cmn:base-obj-id-type {
+	            range "1..127";
+            }
+            description "Map identifier.";
+        }
+
+        leaf name {
+            type string {
+                length 32;
+            }
+            description "Optional user-provided name for the map";
+        }
+
+        list entry {
+            key "dscp";
+            leaf dscp {
+                type inet:dscp;
+                description "incoming dscp value";
+            }
+
+            leaf tc {
+                type base-cmn:traffic-class;
+                description "Traffic class that given dscp is mapped to";
+            }
+
+            leaf color {
+                type packet-color;
+                description "Packet color that given dscp is mapped to";
+            }
+        }
+    }
+
+    list tc-to-queue-map {
+        key "id";
+        description "This defines a map which maps the packet traffic class
+                     to a queue id.
+                     A valid tc-to-queue-map id can then be applied to a port.";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this interface belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf name {
+            type string {
+                length 32;
+            }
+            description "Optional user-provided name for the map";
+        }
+
+        leaf id {
+            type base-cmn:base-obj-id-type {
+	            range "1..127";
+            }
+            description "Map identifier.";
+        }
+
+        list entry {
+            key "tc type";
+            leaf tc {
+                type base-cmn:traffic-class;
+                description "Traffic class";
+            }
+
+            leaf type {
+                type queue-type;
+                description "Queue type";
+            }
+
+            leaf queue-number {
+                type uint32;
+                description "local queue id within a port and a queue type. ";
+            }
+        }
+    }
+
+    list tc-to-dot1p-map {
+        status deprecated;
+
+        key "id";
+        description "This defines a map which maps the traffic class to
+                     egress dot1p values.
+                     A valid tc-to-dot1p-map id can be applied to a port.";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this interface belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf id {
+            type base-cmn:base-obj-id-type {
+	            range "1..127";
+            }
+            description "Map identifier.";
+        }
+
+        leaf name {
+            type string {
+                length 32;
+            }
+            description "Optional user-provided name for the map";
+        }
+
+        list entry {
+            key "tc";
+            leaf tc {
+                type base-cmn:traffic-class;
+                description "Traffic class";
+            }
+
+            leaf dot1p {
+                type base-cmn:dot1p;
+                description "egress dot1p value for this traffic class";
+            }
+        }
+    }
+
+    list tc-to-dscp-map {
+        status deprecated;
+
+        key "id";
+        description "This defines a map which maps the traffic class to
+                     egress dscp values.
+                     A valid tc-to-dscp-map id can be applied to a port.";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this interface belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf id {
+            type base-cmn:base-obj-id-type {
+	            range "1..127";
+            }
+            description "Map identifier.";
+        }
+
+        leaf name {
+            type string {
+                length 32;
+            }
+            description "Optional user-provided name for the map";
+        }
+
+        list entry {
+            key "tc";
+
+            leaf tc {
+                type base-cmn:traffic-class;
+                description "Traffic class";
+            }
+
+            leaf dscp {
+                type inet:dscp;
+                description "egress dscp value for this traffic class";
+            }
+        }
+    }
+
+    list tc-color-to-dot1p-map {
+        key "id";
+        description "This defines a map which maps the traffic class and color to
+                     egress dot1p values.
+                     A valid tc-color-to-dot1p-map id can be applied to a port.";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this interface belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf id {
+            type base-cmn:base-obj-id-type {
+	            range "1..127";
+            }
+            description "Map identifier.";
+        }
+
+        leaf name {
+            type string {
+                length 32;
+            }
+            description "Optional user-provided name for the map";
+        }
+
+        list entry {
+            key "tc color";
+            leaf tc {
+                type base-cmn:traffic-class;
+                description "Traffic class";
+            }
+
+            leaf color {
+                type packet-color;
+                description "Packet color";
+            }
+
+            leaf dot1p {
+                type base-cmn:dot1p;
+                description "egress dot1p value for this traffic class and color";
+            }
+        }
+    }
+
+    list tc-color-to-dscp-map {
+        key "id";
+        description "This defines a map which maps the traffic class and color to
+                     egress dscp values.
+                     A valid tc-color-to-dscp-map id can be applied to a port.";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this interface belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf id {
+            type base-cmn:base-obj-id-type {
+	            range "1..127";
+            }
+            description "Map identifier.";
+        }
+
+        leaf name {
+            type string {
+                length 32;
+            }
+            description "Optional user-provided name for the map";
+        }
+
+        list entry {
+            key "tc color";
+
+            leaf tc {
+                type base-cmn:traffic-class;
+                description "Traffic class";
+            }
+
+            leaf color {
+                type packet-color;
+                description "Packet color";
+            }
+
+            leaf dscp {
+                type inet:dscp;
+                description "egress dscp value for this traffic class and color";
+            }
+        }
+    }
+
+    list tc-to-priority-group-map {
+        key "id";
+        description "This map defines how a traffic class is mapped to a priority group,
+                     which defines how to enforce flow control on an ingress packet";
+
+        leaf id {
+            type base-cmn:base-obj-id-type {
+	            range "1..127";
+            }
+            description "Map identifier.";
+        }
+
+        leaf name {
+            type string {
+                length 32;
+            }
+            description "Optional user-provided name for the map";
+        }
+
+        list entry {
+            key "tc";
+            leaf tc {
+                type base-cmn:traffic-class;
+                description "Traffic class";
+            }
+
+            leaf priority-group {
+                type uint8;
+                description "local Priority group id";
+            }
+        }
+    }
+
+    list priority-group-to-pfc-priority-map {
+        key "id";
+        description "This map defines how a priority group is mapped to one or multiple
+                     pfc-priorities";
+
+        leaf id {
+            type base-cmn:base-obj-id-type {
+	            range "1..127";
+            }
+            description "Map identifier.";
+        }
+
+        leaf name {
+            type string {
+                length 32;
+            }
+            description "Optional user-provided name for the map";
+        }
+
+        list entry {
+            key "priority-group pfc-priority";
+            leaf priority-group {
+                type uint8;
+                description "local Priority group id";
+            }
+
+            leaf pfc-priority {
+                type base-cmn:dot1p;
+                description "PFC priority for outgoing PAUSE frame";
+            }
+        }
+    }
+
+    list pfc-priority-to-queue-map {
+        key "id";
+        description "This map defines how PFC priority from a received PAUSE frame
+                     is mapped to an egress queue.
+                     When applied on a port, it tells which egress queue should
+                     honor a peer node's PFC request.";
+        leaf id {
+            type base-cmn:base-obj-id-type {
+	            range "1..127";
+            }
+            description "Map identifier.";
+        }
+
+        leaf name {
+            type string {
+                length 32;
+            }
+            description "Optional user-provided name for the map";
+        }
+
+        list entry {
+            key "pfc-priority type";
+            leaf pfc-priority {
+                type base-cmn:dot1p;
+                description "PFC priority from the incoming PAUSE frame";
+            }
+
+            leaf type {
+                type queue-type;
+                description "Queue type";
+            }
+
+            leaf queue-number {
+                type uint32;
+                description "local queue id within a port and a queue type. ";
+            }
+        }
+    }
+
+    list buffer-pool {
+        key "id mmu-index";
+        description "buffer pool";
+
+        leaf id {
+            type base-cmn:base-obj-id-type {
+	            range "1..32";
+            }
+            description "buffer pool id";
+        }
+
+        leaf mmu-index {
+            type uint32;
+            default 0;
+            description "To create or configure buffer pool, MMU-index must be 0.
+                No individual MMU configuration will be accepted.
+                Non-zero MMU-index can be used in a multi-MMU system to retrieve
+                the buffer-pool state on a specific MMU.";
+        }
+
+        leaf shared-size {
+            type uint32;
+            config false;
+            description "This is the available buffer size in bytes
+                         that can be shared. This is derived from
+                         substracting all reserved buffers.";
+        }
+
+        leaf pool-type {
+            mandatory true;
+            type buffer-pool-type;
+            description "buffer pool type: Ingress or Egress buffer pool";
+        }
+
+        leaf size {
+            mandatory true;
+            type uint32;
+            description "the total size of this buffer pool in bytes";
+        }
+
+        leaf threshold-mode {
+            type buffer-threshold-mode;
+            description "Shared threshold mode for the buffer pool.
+                         STATIC means the threshold is defined in bytes;
+                         DYNAMIC means the threshold is defined in relative size
+                         of the shared buffer.";
+        }
+        leaf xoff-size {
+            type uint32;
+            description "Shared headroom pool size in bytes for lossless traffic.";
+        }
+
+        leaf wred-profile-id {
+            type base-cmn:base-obj-id-type;
+            description "WRED profile associated with the pool.
+                    WRED Drop/ECN marking based on pool threshold will happen
+                    only when at least one of the queues refers to this buffer pool
+                    and the queue is configured to enable WRED.";
+        }
+    }
+
+    list buffer-pool-stat {
+        key "id mmu-index";
+
+        description "This defines QoS buffer pool statistics.";
+
+        leaf id {
+            type base-cmn:base-obj-id-type;
+            description "buffer pool id";
+        }
+
+        leaf mmu-index {
+            type uint32;
+            default 0;
+            description "In multi-MMU system, if non-zero MMU-index is
+                provided, statistics on the specific MMU will be reported.";
+        }
+
+        leaf current-occupancy-bytes {
+            type yang:counter64;
+            config false;
+            description "current shared buffer occupancy in bytes";
+        }
+
+        leaf watermark-bytes {
+            type yang:counter64;
+            description "watermark in the shared buffer in bytes";
+        }
+
+        leaf xoff-headroom-occupancy-bytes {
+            type yang:counter64;
+            config false;
+            description "current headroom buffer occupancy in bytes";
+        }
+
+        leaf xoff-headroom-watermark-bytes {
+            type yang:counter64;
+            description "watermark in the headroom buffer in bytes";
+        }
+
+        uses wred-stat;
+
+        uses wred-ecn-stat;
+    }
+
+    list buffer-profile {
+        key "id";
+        description "Buffer Profiles";
+
+        leaf id {
+            type base-cmn:base-obj-id-type {
+	            range "1..256";
+            }
+            description "buffer profile id";
+        }
+
+        leaf pool-id {
+            mandatory true;
+            type base-cmn:base-obj-id-type;
+            description "buffer pool to be occupied.
+                         Zero means no buffer pool is specified;
+                         instead global port buffer will be used.";
+        }
+
+        leaf buffer-size {
+            mandatory true;
+            type uint32;
+            description "buffer size to be reserved";
+        }
+
+        leaf threshold-mode {
+            type buffer-threshold-mode;
+            description "If set, this overrides buffer-pool threshold-mode.
+                         If not set, use buffer-pool threshold-mode as default.";
+        }
+
+        leaf shared-dynamic-threshold {
+            type uint8;
+            description "This attribute provides an index to an Alpha value,
+                         which is used to calculate the dynamic threshold for
+                         shared buffer usage.
+                         The valid range is [0..10], an index to the following
+                         array of Alpha values,
+                             [1/128, 1/64, 1/32, 1/16, 1/8, 1/4, 1/2, 1, 2, 4].
+                         The dynamic buffer threshold is calculated based on
+                         the following formula:
+                             (Alpha) / ((Number_of_Active_Queues * Alpha) + 1)
+                         For example, if Number_of_Active_Queues = 1, then the
+                         shared-dynamic-threshold setting of [0..10] results in
+                         [1/129, 1/65, 1/33, 1/17, 1/9, 1/5, 1/3, 1/2, 2/3, 4/5,
+                          8/9] of total shared buffer respectively.";
+        }
+
+        leaf shared-static-threshold {
+            type uint32;
+            description "Static threshold for the shared usage in bytes.
+                         Mandatory when the buffer pool threshold mode
+                         is static. Zero means no limit for the shared usage";
+        }
+
+        leaf xoff-threshold {
+            type uint32;
+            description "Generate XOFF when available buffer in the
+                         priority group buffer is below this threshold.";
+        }
+
+        leaf xon-threshold {
+            type uint32;
+            description "XON non-hysteresis threshold in byte.
+                         Generate XON when the total buffer usage of the PG is
+                         less than the maximum of xon-threshold and the total
+                         buffer limit minus xon-offset-threshold, and available
+                         buffer in the PG buffer is larger than the XOFF threshold.
+                         The XON trigger condition is governed by:
+                         total buffer usage <=
+                         max(xon-threshold, total buffer limit - xon-offset-threshold)";
+        }
+
+        leaf xon-offset-threshold {
+            type uint32;
+            description "XON hysteresis threshold in byte.
+                         Generate XON when the total buffer usage of the PG is
+                         less than the maximum of xon-threshold and the total
+                         buffer limit minus xon-offset-threshold, and available
+                         buffer in the PG buffer is larger than the XOFF threshold.
+                         The XON trigger condition is governed by:
+                         total buffer usage <=
+                         max(xon-threshold, total buffer limit - xon-offset-threshold)";
+        }
+
+        leaf name {
+            type string {
+                length 32;
+            }
+            description "Optional user-provided name for the buffer profile";
+        }
+    }
+
+    list priority-group {
+        key "port-id local-id";
+        description "Ingress priority group";
+
+        leaf port-id {
+            type base-cmn:logical-ifindex;
+            description "Physical port to which this priority group belongs.";
+        }
+
+        leaf local-id {
+            type uint8;
+            description "locally unique priority group id within a port.";
+        }
+
+        leaf id {
+            type base-cmn:base-obj-id-type;
+            config false;
+            description "unique priority group id across the whole switch
+                         assigned to this priority group of this port";
+        }
+
+        leaf buffer-profile-id {
+            type base-cmn:base-obj-id-type;
+            description "buffer profile id associated to the priority group";
+        }
+
+        leaf-list mmu-index-list {
+            config false;
+            type uint32;
+            description "In multi-MMU (Memory Management Unit) architecture,
+                         1-based indexes of the MMUs where the priority group
+                         is present.";
+        }
+    }
+
+    list priority-group-stat {
+        key "port-id local-id mmu-index";
+
+        description "This defines QoS priority group counter statistics.";
+
+        leaf port-id {
+            type base-cmn:logical-ifindex;
+            description "Physical port to which this queue belongs.";
+        }
+
+        leaf local-id {
+            type uint8;
+            description "locally unique priority group id within a port.";
+        }
+
+        leaf mmu-index {
+            type uint32;
+            default 0;
+            description "In multi-MMU system, if non-zero MMU-index is
+                provided, statistics on the specific MMU will be reported.";
+        }
+
+        leaf packets {
+            type yang:counter64;
+            description "rx packets count";
+        }
+
+        leaf bytes {
+            type yang:counter64;
+            description "rx bytes count";
+        }
+
+        leaf current-occupancy-bytes {
+            type yang:counter64;
+            config false;
+            description "current priority group occupancy in bytes";
+        }
+
+        leaf watermark-bytes {
+            type yang:counter64;
+            description "watermark of the priority group in bytes";
+        }
+
+        leaf shared-current-occupancy-bytes {
+            type yang:counter64;
+            config false;
+            description "current priority group shared occupancy in bytes";
+        }
+
+        leaf shared-watermark-bytes {
+            type yang:counter64;
+            description "shared occupancy watermark of the priority group in bytes";
+        }
+
+        leaf xoff-room-current-occupancy-bytes {
+            type yang:counter64;
+            config false;
+            description "current priority group xoff room occupancy in bytes";
+        }
+
+        leaf xoff-room-watermark-bytes {
+            type yang:counter64;
+            description "priority group xoff room occupancy watermark in bytes";
+        }
+
+    }
+
+    list port-ingress {
+        key "port-id";
+        description
+            "Ingress QoS parameters associated with an interface";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this interface belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf port-id {
+            type base-cmn:logical-ifindex;
+            description "Physical port on which QoS ingress params are configured.
+                         Logical ports like LAG interfaces are not allowed.";
+        }
+
+        leaf default-traffic-class {
+            type uint32;
+            description "Default traffic class assigned to packets on non-trusted ports";
+            default 0;
+        }
+
+        leaf dot1p-to-tc-map {
+            type base-cmn:base-obj-id-type;
+            description "A valid dot1p-to-tc-map id will enable trust-dot1p on the port;
+                         A null map-id (0) will disable the trust dot1p functionality.";
+        }
+
+        leaf dot1p-to-color-map {
+            type base-cmn:base-obj-id-type;
+            description "A valid dot1p-to-color-map id will color the incoming packet
+                         on the port according to the dot1p value of the packet.";
+        }
+
+        leaf dot1p-to-tc-color-map {
+            status deprecated;
+            type base-cmn:base-obj-id-type;
+            description "A valid dot1p-to-tc-color-map id will enable trust-dot1p on the port,
+                         (assigning traffic class) and color the incoming packet
+                         on the port according to the dot1p value of the packet.";
+        }
+
+        leaf dscp-to-tc-map {
+            type base-cmn:base-obj-id-type;
+            description "A valid dscp-to-tc-map id will enable trust-dscp on the port;
+                         A null map-id (0) will disable the trust-dscp functionality.";
+        }
+
+        leaf dscp-to-color-map {
+            type base-cmn:base-obj-id-type;
+            description "A valid dscp-to-color-map id will color the incoming packet
+                         on the port according to the dscp value of the packet.";
+        }
+
+        leaf dscp-to-tc-color-map {
+            status deprecated;
+            type base-cmn:base-obj-id-type;
+            description "A valid dscp-to-color-map id will enable trust-dscp on the port,
+                         (assigning traffic class) and color the incoming packet
+                         on the port according to the dscp value of the packet.";
+        }
+
+        leaf tc-to-queue-map {
+            type base-cmn:base-obj-id-type;
+            description "A valid tc-to-queue-map id defines which queue the incoming
+                         packet on this source port is sent to;
+                         a Null tc-to-queue-map id (0) disable the use of map to
+                         queue a packet.";
+        }
+
+        leaf flow-control {
+            type flow-control;
+            description "TX/RX flow control setting";
+        }
+
+        leaf policer_id {
+            type base-cmn:base-obj-id-type;
+            description "Port policer Id";
+        }
+
+        leaf flood_storm_control {
+            type base-cmn:base-obj-id-type;
+            description "unknown unicast and unknown multicast storm control policer id";
+        }
+
+        leaf broadcast_storm_control {
+            type base-cmn:base-obj-id-type;
+            description "broadcast storm control policer id";
+        }
+
+        leaf multicast_storm_control {
+            type base-cmn:base-obj-id-type;
+            description "multicast storm control policer id";
+        }
+
+        leaf priority_group_number {
+            config false;
+            type uint32;
+            description "Number of priority groups on this port";
+        }
+
+        leaf-list priority_group_id_list {
+            config false;
+            type base-cmn:base-obj-id-type;
+            description "list of priority group ids associated to the port";
+        }
+
+        leaf per_priority_flow_control {
+            type uint8;
+            description "bit vector to enable/disable port PFC.
+                         Valid from bit 0 to bit 7";
+        }
+
+        leaf tc-to-priority-group-map {
+            type base-cmn:base-obj-id-type;
+            description "A valid tc-to-priority-group-map id defines which priority
+                         group a packet of a traffic class belongs to.
+                         A priority group can apply flow control on the ingress packet.";
+        }
+
+        leaf priority-group-to-pfc-priority-map {
+            type base-cmn:base-obj-id-type;
+            description "A valid priority-group-to-pfc-priority-map id defines
+                         which pfc-priority or pfc-priorities is used for outgoing PAUSE frame
+                         when a priority group is congested.";
+        }
+
+        leaf-list buffer-profile-id-list {
+            type base-cmn:base-obj-id-type;
+            description "ingress buffer profile id list";
+        }
+    }
+
+    list port-egress {
+        key "port-id";
+        description
+            "Egress QoS parameters associated with an interface";
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            description "Logical Switch to which this interface belongs.
+                         The concept of logical switch is obsolete and this
+                         attribute is ignored.";
+            status obsolete;
+        }
+
+        leaf port-id {
+            type base-cmn:logical-ifindex;
+            description "Physical port on which QoS egress params are configured.
+                         Logical ports like LAG interfaces are not allowed.";
+        }
+
+        leaf buffer-limit {
+            type uint64;
+            description "Per Port Buffer limit in bytes";
+        }
+
+        leaf wred-profile-id {
+            type base-cmn:base-obj-id-type;
+            description "WRED profile associated with the port";
+            status obsolete;
+        }
+
+        leaf scheduler-profile-id {
+            type base-cmn:base-obj-id-type;
+            description "Scheduler profile Id associated to this port
+                         for port rate shaping";
+        }
+
+        leaf num-unicast-queue {
+            config false;
+            type uint8;
+            description "Number of egress unicast queues associated per port";
+        }
+
+        leaf num-multicast-queue {
+            config false;
+            type uint8;
+            description "Number of egress multicast queues associated per port";
+        }
+
+        leaf num-queue {
+            config false;
+            type uint8;
+            description "Number of egress queues associated per port
+                         for both unicast and multicast traffic";
+        }
+
+        leaf-list queue-id-list {
+            config false;
+            type base-cmn:base-obj-id-type;
+            description "List of all queue ids associated to the port";
+        }
+
+        leaf tc-to-queue-map {
+            type base-cmn:base-obj-id-type;
+            description "A valid tc-to-queue-map id defines which queue the packet
+                         is sent to on this destination port;
+                         a Null tc-to-queue-map id (0) disable the use of map to
+                         queue a packet.";
+        }
+
+        leaf tc-to-dot1p-map {
+            status deprecated;
+            type base-cmn:base-obj-id-type;
+            description "A valid tc-to-dot1p-map id defines what dot1p value is set
+                         for a packet egressing this destination port;
+                         a Null tc-to-dot1p-map id (0) disable the use of map to
+                         set dot1p value of a packet.";
+        }
+
+        leaf tc-to-dscp-map {
+            status deprecated;
+            type base-cmn:base-obj-id-type;
+            description "A valid tc-to-dscp-map id defines what dscp value is set
+                         for a packet egressing this destination port;
+                         a Null tc-to-dscp-map id (0) disable the use of map to
+                         set dscp value of a packet.";
+        }
+
+        leaf tc-color-to-dot1p-map {
+            type base-cmn:base-obj-id-type;
+            description "A valid tc-color-to-dot1p-map id defines what dot1p value is set
+                         for a packet egressing this destination port;
+                         a Null tc-color-to-dot1p-map id (0) disable the use of map to
+                         set dot1p value of a packet.";
+        }
+
+        leaf tc-color-to-dscp-map {
+            type base-cmn:base-obj-id-type;
+            description "A valid tc-color-to-dscp-map id defines what dscp value is set
+                         for a packet egressing this destination port;
+                         a Null tc-color-to-dscp-map id (0) disable the use of map to
+                         set dscp value of a packet.";
+        }
+
+        leaf pfc-priority-to-queue-map {
+            type base-cmn:base-obj-id-type;
+			description "A valid pfc-prioirity-to-queue-map id defines which egress
+			             queue shall honor a peer node's PFC request based on
+			             the PFC priority of a received PAUSE frame." ;
+        }
+
+        leaf-list buffer-profile-id-list {
+            type base-cmn:base-obj-id-type;
+            description "egress buffer profile id list";
+        }
+    }
+    list port-pool {
+        key "port-id buffer-pool-id";
+        description "This list defines per interface per buffer pool characteristics";
+        	
+        leaf port-id {
+            type base-cmn:logical-ifindex;
+            description "Physical port on which QoS egress params are configured.
+                         Logical ports like LAG interfaces are not allowed.";
+            mandatory true;
+        }
+
+        leaf buffer-pool-id {
+            type base-cmn:base-obj-id-type;
+            description "Buffer pool id of the interface.";
+            mandatory true;
+        }
+       	
+        leaf wred-profile-id {
+    	    type base-cmn:base-obj-id-type;
+            description "WRED profile to be applied";
+        }
+    }
+
+    list port-pool-stat {
+        key "port-id buffer-pool-id";
+        description "This list defines per interface per buffer pool counter statistics";
+        	
+        leaf port-id {
+            type base-cmn:logical-ifindex;
+            description "Physical port on which QoS egress params are configured.
+                         Logical ports like LAG interfaces are not allowed.";
+        }
+
+        leaf buffer-pool-id {
+            type base-cmn:base-obj-id-type;
+            description "Buffer pool id of the interface.";
+        }
+       	
+        uses wred-stat;
+
+        uses wred-ecn-stat;
+
+        uses buffer-stat;
+    }
+
+    grouping wred-stat {
+        leaf green-discard-dropped-packets {
+            type yang:counter64;
+            description "WRED green color dropped packets count";
+        }
+
+        leaf green-discard-dropped-bytes {
+            type yang:counter64;
+            description "WRED green color dropped bytes";
+        }
+
+        leaf yellow-discard-dropped-packets {
+            type yang:counter64;
+            description "WRED yellow color dropped packets count";
+        }
+
+        leaf yellow-discard-dropped-bytes {
+            type yang:counter64;
+            description "WRED yellow color dropped bytes";
+        }
+
+        leaf red-discard-dropped-packets {
+            type yang:counter64;
+            description "WRED red color dropped packets count";
+        }
+
+        leaf red-discard-dropped-bytes {
+            type yang:counter64;
+            description "WRED red color dropped bytes";
+        }
+
+        leaf discard-dropped-packets {
+            type yang:counter64;
+            description "WRED dropped packets count";
+        }
+
+        leaf discard-dropped-bytes {
+            type yang:counter64;
+            description "WRED dropped bytes";
+        }
+    }
+
+    grouping wred-ecn-stat {
+        leaf green-wred-ecn-marked-packets {
+            type yang:counter64;
+            description "WRED green color ECN marked packets count";
+        }
+
+        leaf green-wred-ecn-marked-bytes {
+            type yang:counter64;
+            description "WRED green color ECN marked bytes";
+        }
+
+        leaf yellow-wred-ecn-marked-packets {
+            type yang:counter64;
+            description "WRED yellow color ECN marked packets count";
+        }
+
+        leaf yellow-wred-ecn-marked-bytes {
+            type yang:counter64;
+            description "WRED yellow color ECN marked bytes";
+        }
+
+        leaf red-wred-ecn-marked-packets {
+            type yang:counter64;
+            description "WRED red color ECN marked packets count";
+        }
+
+        leaf red-wred-ecn-marked-bytes {
+            type yang:counter64;
+            description "WRED red color ECN marked bytes";
+        }
+
+        leaf wred-ecn-marked-packets {
+            type yang:counter64;
+            description "WRED ECN marked packets count";
+        }
+
+        leaf wred-ecn-marked-bytes {
+            type yang:counter64;
+            description "WRED ECN marked bytes";
+        }
+    }
+
+
+    grouping buffer-stat {
+        leaf current-occupancy-bytes {
+            type yang:counter64;
+            config false;
+            description "current buffer occupancy in bytes";
+        }
+
+        leaf watermark-bytes {
+            type yang:counter64;
+            description "watermark bytes";
+        }
+
+        leaf shared-current-occupancy-bytes {
+            type yang:counter64;
+            description "current shared buffer occupancy in bytes";
+        }
+
+        leaf shared-watermark-bytes {
+            type yang:counter64;
+            description "shared buffer occupancy watermark in bytes";
+        }
+    }
+    
+    grouping thresholds {
+
+        leaf min-threshold {
+            type uint32;
+            description "Minimum threshold in bytes after which packets will
+                be dropped based on the drop probability";
+        }
+
+        leaf max-threshold {
+            type uint32;
+            description "Maximum threshold in bytes after which packets will be
+                tail dropped";
+        }
+
+        leaf probability {
+            type uint32 {range "0..100";}
+            default 100;
+            description "Percentage probability with which packets will be
+                dropped or ecn-marked when minimum threshold is reached";
+        }
+
+    }
+}

--- a/python-inocybe-openswitch/models/base-routing.yang
+++ b/python-inocybe-openswitch/models/base-routing.yang
@@ -1,0 +1,966 @@
+module base-routing {
+
+namespace "http://www.dellemc.com/networking/os10/dell-base-routing";
+prefix "base-route";
+
+import ietf-yang-types {
+  prefix yang;
+}
+import ietf-inet-types {
+  prefix inet;
+}
+
+import base-common {
+   prefix "base-cmn";
+}
+
+import base-interface-common {
+   prefix "base-if";
+}
+
+organization
+"Dell EMC";
+
+contact
+"http://www.dell.com/support";
+
+description
+"This module contains a collection of YANG definitions for
+managing configuration and operational data for Routing Object";
+
+revision 2018-04-05 {
+    description
+        "This revision adds the NH VRF name in the existing RPC to append or
+        delete nexthop(s) to/from an existing leaked route from one VRF to another.";
+    reference
+        "Network Platform Abstraction";
+}
+
+revision 2018-04-02 {
+    description
+        "This revision adds the VRF name in the next-hop entry to support the route leaking from one VRF to another.";
+    reference
+        "Network Platform Abstraction";
+}
+
+revision 2018-03-12 {
+description
+    "This revision adds the support for proxy ARP enable/disable on router interface.";
+reference
+    "Update since last revision.";
+}
+
+revision 2018-02-09 {
+description
+"This revision adds the config support for virtual routing
+ configuration object to configure peer IP.";
+}
+
+revision 2018-01-23 {
+description
+"This revision adds the config support for ICMP redirects.";
+}
+
+revision 2017-01-11 {
+description
+"This revision adds the event filter to publish the selective routes,
+by default, no route events will be published.";
+}
+
+revision 2016-04-05 {
+description
+"VLT Peer routing enable/disable support";
+}
+
+revision 2014-08-06 {
+description
+"Initial revision.";
+}
+
+/*
+* Typedefs
+*/
+
+/*
+* Identities
+*/
+
+identity routing-object-base {
+description
+"Base identity from which specific routing protocols are
+derived.";
+}
+
+/*
+* Features
+*/
+
+/*
+ *  typedefs
+ */
+ typedef rt-owner {
+   		type enumeration {
+            enum os-static {
+              value 1;
+            }
+            enum os-privileged {
+              value 2;
+            }
+            enum dc-rtm {
+              value 3;
+            }
+            enum mgmtroute {
+              value 4;
+            }
+            enum zebra {
+              value 5;
+            }
+            enum bird {
+              value 6;
+            }
+            enum thirdparty-apps {
+              value 7;
+            }
+       	}
+  }
+
+typedef rt-type {
+	type enumeration {
+        enum static {
+          value 1;
+        }
+        enum dynamic {
+          value 2;
+        }
+    }
+}
+
+typedef nh-type {
+  type enumeration {
+        enum regular {
+          value 1;
+        }
+        enum interface {
+          value 2;
+        }
+        enum null0 {
+          value 3;
+        }
+        enum loopback {
+          value 4;
+        }
+	    enum ecmp {
+          value 5;
+        }
+	    enum wecmp {
+          value 6;
+        }
+	    enum protection-switching {
+          value 7;
+        }
+	    enum other {
+          value 8;
+        }
+   }
+ }
+
+ typedef hash-info {
+ type enumeration {
+            enum mac-based {
+              value 1;
+            }
+            enum ip {
+              value 2;
+            }
+            enum mac-ip {
+              value 3;
+            }
+        }
+ }
+
+  typedef rt-status {
+	  type enumeration {
+       enum up {
+       		value 1;
+   		 }
+       enum down {
+       		value 2;
+ 		 }
+ 	 }
+  }
+
+ typedef rt-mode {
+	  type enumeration {
+    	       enum default {
+                    value 1;
+                 }
+                 enum scaled-l3-hosts {
+                    value 2;
+                 }
+                 enum scaled-l3-routes {
+                    value 3;
+                 }
+       }
+  }
+
+  typedef neighbor-state {
+    type enumeration {
+        enum incomplete {
+            value 1;
+        }
+        enum reachable {
+            value 2;
+        }
+        enum stale {
+            value 4;
+        }
+        enum delay {
+            value 8;
+        }
+        enum probe {
+            value 16;
+        }
+    }
+  }
+
+ typedef rt-operation-type {
+   type enumeration {
+      enum append {
+         value 1;
+         description "Operation to append nexthop(s) to an existing route";
+      }
+      enum delete {
+         value 2;
+         description "Operation to delete nexthop(s) from an existing route";
+      }
+   }
+ }
+
+
+  typedef special-next-hop {
+    type enumeration {
+      enum blackhole {
+        value 1;
+        description
+          "Silently discard the packet.";
+      }
+      enum unreachable {
+        value 2;
+        description
+          "Discard the packet and notify the sender with an error
+           message indicating that the destination host is unreachable.";
+      }
+      enum prohibit {
+        value 3;
+        description
+          "Discard the packet and notify the sender with an error
+           message indicating that the communication is
+           administratively prohibited.";
+      }
+      enum receive {
+        value 4;
+        description
+          "The packet will be received by the local system.";
+      }
+    }
+  }
+/*
+* Configuration of the core elements of the Switch
+*/
+ grouping next-hop {
+	description
+	  "Next Hop info";
+      leaf nh-id {
+       type uint32;
+         description "ID for next-hop";
+        }
+
+    leaf nh-addr {
+      type inet:ip-address;
+      description "IP address";
+    }
+
+    leaf ifindex {
+      type base-cmn:logical-ifindex;
+      description "Logical IF index must be interace type or null0 type for routes";
+    }
+
+    leaf ifname {
+      type string;
+      description "Name of the interface through which this next-hop is reachable";
+    }
+
+	leaf weight {
+	  type uint32;
+	  description "Used for Weighted ECMP";
+ 	}
+	leaf resolved {
+	  type boolean;
+	  description "Is nexthop resolved?";
+ 	}
+    leaf  npu-prg-done{
+          type boolean;
+          default false;
+          description "Is NPU programming done for this entry?";
+     }
+ }
+
+   grouping next-hop-entry {
+      description
+       "Grouping of the next hop entry";
+
+      leaf nh-vrf-name {
+          type string;
+          description "VRF device name";
+      }
+
+      leaf nh-count {
+        type uint32;
+        description "Number of next hops";
+      }
+
+      leaf group-id {
+       type uint32;
+          description "ECMP group ID or Non-ECMP nexthop ID";
+        }
+
+      leaf nh-type {
+        type nh-type;
+        description "Type of next hop";
+      }
+
+     leaf hash-info {
+        type hash-info;
+        description "Hashing mechanisms";
+      }
+
+      list nh-list {
+        key "nh-addr";
+        description
+            "Next-Hop info depending on the number of next-hops";
+        uses next-hop;
+      }
+
+   }
+
+   grouping special-next-hop-entry {
+      description
+         "This grouping provides a leaf with an enumeration of special
+          next-hops.";
+
+      leaf special-next-hop {
+         type special-next-hop;
+         description
+            "Special next-hop options.";
+      }
+   }
+
+
+   grouping l3-route-entry {
+     description
+	"This grouping defines the l3 route entry";
+
+    leaf vrf-id {
+      type uint32;
+      description "VRF ID";
+      status obsolete;
+    }
+
+
+    leaf route-prefix {
+      type inet:ip-address;
+	     description "route address";
+    }
+
+    leaf prefix-len {
+      type uint32;
+      description "Prefix Length";
+    }
+
+    leaf af {
+      type base-cmn:af-type;
+      description "Address Family";
+    }
+
+     uses next-hop-entry;
+
+     leaf epoch-time {
+      type uint64;
+      description "epoch time of the route when it got updated";
+     }
+
+    leaf distance {
+      type uint16;
+      description "Protocol admin distance";
+    }
+
+    leaf protocol {
+      type uint16;
+      description "Protocol";
+    }
+
+    leaf ifindex {
+      type base-cmn:logical-ifindex;
+      description "Logical IF index";
+    }
+
+    leaf ifname {
+      type string;
+      description "Name of the interface on which this route is configured/learnt";
+    }
+
+    leaf owner {
+	  type rt-owner;
+      description "Owner: OS Kernel Privileged, Static, DC-RTM, DC-RTM Static, Quagga etc";
+    }
+
+     leaf static-route {
+       type boolean;
+       description "Is route static or owned by other protocol";
+     }
+
+     leaf  npu-prg-done{
+          type boolean;
+          default false;
+          description "Is NPU programming done for this entry?";
+     }
+
+     uses special-next-hop-entry;
+   }
+
+grouping l3-neighbor-entry {
+description
+"This grouping defines a neighbor-table entry";
+    leaf address {
+      type inet:ip-address;
+        description "IP address";
+     }
+
+     leaf mac-addr {
+        type yang:mac-address;
+        description "MAC address";
+     }
+
+    leaf vrf-id {
+      type uint32;
+      description "VRF ID";
+      status obsolete;
+    }
+
+    leaf af {
+      type base-cmn:af-type;
+      description "Address Family";
+    }
+
+    leaf ifindex {
+      type base-cmn:logical-ifindex;
+      description "Logical IF index";
+    }
+
+    leaf ifname {
+      type string;
+      description "Name of the interface through which this neighbor is reachable";
+    }
+
+    leaf owner {
+       type rt-owner;
+      description "Owner: OS Kernel DC-RTM, Management Route, Third party app etc";
+    }
+
+    leaf flags {
+      type uint32;
+      description "Neighbor flags";
+    }
+    leaf state {
+      type uint32;
+      description "Dynamic neighbor entry states";
+    }
+
+    leaf type {
+       type  rt-type;
+		description  "Neighbor entry type";
+	}
+
+    leaf age-timeout {
+	type uint32;
+	units "seconds";
+	description "age timeout";
+    }
+    leaf  npu-prg-done{
+          type boolean;
+          default false;
+          description "Is NPU programming done for this entry?";
+    }
+  }
+
+
+list obj {
+ key "vrf-name";
+ description "This grouping defines the routing domain object";
+
+ leaf vrf-id {
+  type uint32;
+  description "vrf-name is used in place of vrf-id.";
+  status obsolete;
+ }
+
+ leaf vrf-name {
+  type string;
+  description "VRF device name";
+ }
+
+ leaf switch-id {
+   type uint32;
+   description "Logical Switch to which this routing-domain belongs.";
+ }
+
+ leaf status {
+  type rt-status;
+  description "Status of the routing-object-instance";
+ }
+
+  /* The get on the below entry will return the output for
+   * show {ip | ipv6} fib <prefix>/<pref-len> */
+ list entry {
+   key "af route-prefix prefix-len";
+   description "An entry of a L3 route table";
+   uses l3-route-entry;
+ }
+
+ list nbr {
+   key "af address" ;
+   description "An entry of a neighbor (ARP/ND) table";
+   uses l3-neighbor-entry;
+ }
+
+ leaf nsf-enabled {
+	  type boolean;
+	  description "Is NSF enabled?";
+ }
+
+ leaf eor {
+	  type boolean;
+	  description "Is End of RIB reached ?";
+ }
+
+}
+
+
+/*
+  * Route/Next-hop tracking service
+  */
+
+grouping nexthop-tracking-object {
+
+    leaf vrf-id {
+      type uint32;
+      description "VRF ID";
+      status obsolete;
+    }
+
+    leaf vrf-name {
+      type string;
+      description "VRF device name";
+    }
+    leaf af {
+      type base-cmn:af-type;
+      description "Address Family";
+    }
+
+    leaf dest-addr {
+      type inet:ip-address;
+      description "Route/Nexthop address to be tracked";
+    }
+
+    leaf data {
+      type base-cmn:ip-nexthop-group-opaque-data;
+      description
+         "Opaque blob containing hardware specific data for
+          the Next-Hop Group ID/Egress object ID as returned by NPU for single or multipath Nexthop";
+    }
+
+    leaf nh-count {
+      type uint32;
+      description "Number of next hops in resolved status";
+    }
+
+    list nh-info {
+      key "af address" ;
+      description "An entry of a neighbor (ARP/ND) table that's in resolved status";
+                   uses l3-neighbor-entry;
+    }
+  }
+
+  list nh-track {
+    key "vrf-id af dest-addr";
+    description "Route/Nexthop Tracking Service";
+                 uses nexthop-tracking-object;
+  }
+
+
+ /*
+  * Configuration of the routing-forwarding-domain elements of the Switch
+  */
+
+
+  grouping hardware-forwarding-configuration-table {
+
+      leaf vrf-id {
+        type uint32;
+        description "VRF ID";
+        status obsolete;
+      }
+
+     leaf hash-algo-seed-val {
+          type uint32;
+         description "hash-algorithm seed value ";
+     }
+
+     leaf enable-v4 {
+       type boolean;
+       default true;
+       description "Is route ipv4 routing enabled?";
+     }
+
+     leaf enable-v6 {
+       type boolean;
+       default false;
+       description "Is route ipv6 routing enabled?";
+     }
+
+     leaf deterministic-ECMP-v4-enabled {
+       type boolean;
+       default false;
+       description "Is Deterministic-ECMP enabled for ipv4?";
+     }
+
+     leaf deterministic-ECMP-v6-enabled {
+       type boolean;
+       default false;
+       description "Is Deterministic-ECMP enabled for ipv6?";
+     }
+
+     leaf mode {
+ 		type rt-mode;
+         description "hardware-forwarding-table mode";
+     }
+
+    /* Non-stop Forwarding configuration */
+     leaf nsf-v4-enabled {
+       type boolean;
+       default false;
+       description "ipv4 NSF enabled?";
+     }
+
+     leaf nsf-v6-enabled {
+       type boolean;
+       default false;
+       description "ipv6 NSF enabled?";
+     }
+     /*
+      * ip ecmp-group {maximum-paths | {number} | {path-fallback}}
+      */
+     leaf ecmp-group-max-paths {
+        type uint32;
+       description "ecmp-group maximum-paths";
+    }
+
+    leaf ecmp-group-number {
+        type uint32;
+       description "ecmp-group number";
+    }
+
+     leaf ecmp-group-path-fallback {
+       type boolean;
+       default false;
+       description "ecmp-group path-fallback";
+    }
+
+    /*
+     * Inform clients(like RTM) that FIB clear is started and completed in NPU and NAS Routing
+     */
+     leaf start-rtm-download {
+       type boolean;
+       default false;
+       description "Start download of routes from RTM";
+     }
+
+
+      leaf stop-rtm-download {
+       type boolean;
+       default false;
+       description "Indicate to stop download of routes from RTM during clear";
+      }
+
+}
+
+  container fwd-tbl-confg {
+    description "Routing and Forwarding configuration table";
+    uses hardware-forwarding-configuration-table;
+  }
+
+  /* clear { ip | ipv6} fib */
+  rpc flush {
+    description "Clear FIB entries";
+    input {
+        leaf vrf-id {
+            type uint32;
+            default 0;
+            description "VRF ID";
+            status obsolete;
+        }
+
+        leaf vrf-name {
+            type string;
+            description "VRF device name";
+        }
+
+        leaf af {
+            mandatory true;
+            type base-cmn:af-type;
+            description "Address Family of the FIB entries to be cleared";
+        }
+    }
+  }
+ /*
+  * FIB show commands
+  * show {ip | ipv6} fib summary
+  */
+  grouping fib-configuration-table {
+     /*
+      * FIB Show commands
+     */
+      leaf vrf-id {
+        type uint32;
+        description "VRF ID";
+        status obsolete;
+      }
+
+      leaf af {
+      type base-cmn:af-type;
+      description "Address Family";
+     }
+
+     leaf summary {
+       type boolean;
+       default false;
+       description "Show summary command returns the number of FIB route count";
+     }
+
+    leaf route-count {
+       type uint32;
+       description "FIB Route count";
+    }
+  }
+  container fib {
+    description "FIB configuration";
+    uses fib-configuration-table;
+  }
+
+  container peer-routing-config {
+    description "This defines the peer routing enable/disable object";
+
+    leaf vrf-id {
+      type uint32;
+      default 0;
+      description "VRF ID";
+      status obsolete;
+    }
+
+    leaf vrf-name {
+      type string;
+      description "VRF device name";
+    }
+    leaf ifname {
+      type string;
+      description "Physical/Logical L3 interface";
+    }
+
+     leaf peer-mac-addr {
+        type yang:mac-address;
+        description "Peer MAC address";
+     }
+  }
+
+  container virtual-routing-config {
+
+    list virtual-routing-ip-config {
+      key "vrf-name af ifname ip";
+
+      leaf vrf-name {
+        type string;
+        description "VRF device name";
+      }
+
+      leaf af {
+         type base-cmn:af-type;
+         description "Address Family of the peer's IP address to be configured.";
+      }
+
+      leaf ifname {
+        type string;
+        description "Physical/Logical L3 interface";
+      }
+
+      leaf ip {
+         type inet:ip-address;
+         description "Peer IP address to be configured.";
+      }
+
+      description "This defines the virtual routing IP configuration object to configure
+                   the peer routers IP for processing it when receiving it locally.";
+    }
+
+    description "This defines the virtual routing configuration object";
+  }
+
+  rpc route-nh-operation {
+    description "RPC to append or delete nexthop(s) to/from an existing route.";
+    input {
+
+      leaf operation {
+        mandatory true;
+        type rt-operation-type;
+        description "Operation to perform for the given nexthop(s) of an existing route.
+                     This is valid only during update to an existing route.";
+      }
+
+      leaf vrf-id {
+        type uint32;
+        default 0;
+        description "VRF ID";
+        status obsolete;
+      }
+
+      leaf vrf-name {
+        type string;
+        description "VRF device name";
+      }
+
+      leaf af {
+        mandatory true;
+        type base-cmn:af-type;
+        description "Address Family";
+      }
+
+      leaf route-prefix {
+        mandatory true;
+        type inet:ip-address;
+        description "Route address";
+      }
+
+      leaf prefix-len {
+        mandatory true;
+        type uint32;
+        description "Route prefix Length";
+      }
+
+      leaf nh-count {
+        mandatory true;
+        type uint32;
+        description "Number of next hops added/deleted";
+      }
+
+      leaf nh-vrf-name {
+          type string;
+          description "VRF device name for next hop";
+      }
+
+      list nh-list {
+        key "nh-addr";
+        description "Next-Hop info depending on the number of next-hops added/deleted";
+        uses next-hop;
+      }
+    }
+  }
+  list ip-unreachables-config {
+     description "Provide list of network interfaces that can initiate ICMP unreachable messages for non-routable traffic.";
+     key "af ifname";
+
+    leaf af {
+      type base-cmn:af-type;
+      description "Address Family";
+    }
+
+    leaf ifname {
+      type string;
+      description "Network interface";
+    }
+  }
+  rpc interface-mode-change {
+    description "This method is used to notify routing component for change
+      of the interface mode from None to L2 or vice versa.
+      On receiving this notification, routing component will perform the following:
+      when mode changes from None to L2, routing configurations on this interface
+       will be removed from hardware.
+      when mode changes from L2 to None, cached routing configurations (if any)
+       on this interface will be applied to hardware.";
+    input {
+      leaf ifname {
+        mandatory true;
+        type string;
+        description "Interface name for which the mode change is triggered";
+      }
+      leaf mode {
+        mandatory true;
+        type base-if:mode;
+        description "Interface mode in notification.
+          Modes that are of interest to routing component is None/L2.";
+      }
+    }
+  }
+
+  list event-filter {
+    key "vrf-name type";
+    description "Provide list of filters to publish the selective route events,
+                 by default, no route events will be published.";
+    leaf vrf-name {
+        type string;
+        description "VRF device name";
+    }
+
+    leaf type {
+        type rt-owner;
+        description "This type is used to publish the selective route type events,
+                     the event filter is now supported only for management routes.";
+    }
+
+    leaf enable {
+	  type boolean;
+	  description "If this is set to true, the filter will be applied for a selective
+          route type in the VRF and false otherwise.";
+    }
+  }
+
+  list ip-redirects-config {
+     key "vrf-name ifname";
+     description "Provide list of network interfaces that can initiate ICMP redirect messages for routable traffic, when it ingress and egress on same router interface.";
+
+    leaf vrf-name {
+        type string;
+        description "VRF device name";
+    }
+
+    leaf ifname {
+      type string;
+      description "Network interface";
+    }
+  }
+
+  list proxy-arp-config {
+      key "vrf-name ifname";
+      description "Provide list of network interfaces that can reply to ARP request
+                   on behalf of the neighbor for the target IP matching the local subnet.";
+
+      leaf vrf-name {
+          type string;
+          description "VRF device name";
+      }
+
+      leaf ifname {
+          type string;
+          description "Network interface";
+      }
+  }
+
+}

--- a/python-inocybe-openswitch/models/base-sflow.yang
+++ b/python-inocybe-openswitch/models/base-sflow.yang
@@ -1,0 +1,99 @@
+module base-sflow {
+
+    namespace "http://www.dellemc.com/networking/os10/dell-base-sflow";
+    prefix "base-sflow";
+
+    import base-common {
+        prefix "base-cmn";
+    }
+    import ietf-inet-types {
+        prefix "inet";
+    }
+
+    organization
+        "Dell EMC";
+
+    contact
+    "http://www.dell.com/support";
+
+    description
+        "This module contains a collection of YANG definitions provided
+         by platfrom to manage sflow objects";
+
+    revision 2014-02-11 {
+        description
+            "Initial revision";
+    }
+
+    list entry {
+
+        key "id";
+
+        description
+            "sflow session attributes";
+
+		leaf id{
+			type uint32;
+			description
+				"Session id to uniquely identify a sflow session";
+		}
+
+        choice  if {
+            case index {
+                leaf ifindex {
+                    type base-cmn:logical-ifindex;
+                    description
+                        "Interface Index which is unique across switch to identify
+                        logical/physical interface";
+                }
+            }
+            case name {
+                leaf ifname {
+                    type string;
+                    description
+                        "Interface name which is unique across switch to identify
+                        logical/physical interface";
+                }
+            }
+        }
+
+        leaf ifindex {
+            type base-cmn:logical-ifindex;
+            status deprecated;
+        	mandatory true;	
+            description
+            	"Interface index which uniquely identifies physical
+            	 interface in the switch where packet sampling needs to
+            	 to be enabled";
+        }
+
+        leaf direction {
+            type base-cmn:traffic-path;
+            mandatory true;
+            description
+            	"Direction of packets in which sampling needs to be enabled";
+        }
+
+        leaf sampling-rate{
+        	type uint32;
+            mandatory true;
+            description "Rate at which packets sampling needs to be enabled";
+        }
+    }
+
+    container socket-address {
+        description
+            "Address that Sflow Applications need to open UDP socket on
+             to receive sampled packets. Sampled packets from all Sflow
+             sessions are sent to a single UDP socket.";
+
+        leaf ip {
+            type inet:ipv4-address;
+            default 127.0.0.1;
+        }
+        leaf udp-port {
+            type uint16;
+            default 20001;
+        }
+    }
+}

--- a/python-inocybe-openswitch/models/base-stg.yang
+++ b/python-inocybe-openswitch/models/base-stg.yang
@@ -1,0 +1,127 @@
+module base-stg {
+
+    namespace "http://www.dellemc.com/networking/os10/dell-base-stg";
+    prefix "base-stg";
+
+    import base-common {
+        prefix "base-cmn";
+    }
+
+    organization
+        "Dell EMC";
+
+    contact
+    "http://www.dell.com/support";
+
+    description
+        "This module contains a collection of YANG definitions provided
+          by platform for managing STG objects";
+
+    revision 2014-12-30 {
+        description
+            "Initial revision";
+    }
+
+    typedef interface-state {
+        type enumeration {
+            enum DISABLED {
+                value 0;
+                description
+                    "Indicates STP state of the interface is disabled";
+            }
+            enum LISTENING {
+                value 1;
+                description
+                    "Indicates STP state of the interface is listening";
+            }
+            enum LEARNING {
+                value 2;
+                description
+                    "Indicates STP state of the interface is learning";
+            }
+            enum FORWARDING {
+                value 3;
+                description
+                    "Indicates STP state of the interface is forwarding";
+            }
+            enum BLOCKING {
+                value 4;
+                description
+                    "Indicates STP state of the interface is blocking";
+            }
+        }
+    }
+
+    container default-stg{
+        leaf id{
+            config false;
+            type uint32;
+            description "Default STG instance id";
+        }
+
+        leaf state{
+            type interface-state;
+            description
+                "Default STP state of the all interfaces for default STG instance";
+        }
+    }
+
+
+    list entry {
+
+        key "id";
+
+        description
+            "Spanning Tree Group instance attributes";
+
+        leaf id {
+            type uint32;
+            description
+                "Identifier of the Spanning Tree Group instance";
+        }
+
+        leaf switch-id {
+            type base-cmn:logical-switch-id;
+            status obsolete;
+            description
+                "Logical Switch to which this STG instance belongs.";
+        }
+
+        leaf-list vlan {
+            type base-cmn:vlan-id;
+            description
+                "List of VLANs to be associated with the STG instance";
+        }
+
+        list intf {
+            key "if";
+            description
+                "List of interfaces and its STP state to be changed
+                for the given STG instance";
+
+            choice  if {
+                case index {
+                    leaf ifindex {
+                        type base-cmn:logical-ifindex;
+                        description
+                            "Interface Index which is unique across switch to identify
+                            logical/physical interface";
+                    }
+                }
+                case name {
+                    leaf ifname {
+                        type string;
+                        description
+                            "Interface name which is unique across switch to identify
+                            logical/physical interface";
+                    }
+                }
+            }
+            leaf state {
+                type interface-state;
+                description
+                    "STP state of the interface";
+            }
+        }
+    }
+}

--- a/python-inocybe-openswitch/models/base-switch-element.yang
+++ b/python-inocybe-openswitch/models/base-switch-element.yang
@@ -1,0 +1,579 @@
+module base-switch-element {
+
+namespace "http://www.dellemc.com/networking/os10/dell-base-switch-element";
+prefix "base-switch";
+
+import base-common {
+    prefix "base-cmn";
+}
+import ietf-yang-types {
+    prefix "yang";
+}
+
+organization
+"Dell EMC";
+
+contact
+    "http://www.dell.com/support";
+
+description
+"This module contains a collection of YANG definitions for
+managing configuration and operational data for Dell EMC Switch Element";
+
+revision 2018-07-02 {
+description
+"Add Configuration of IPv6 Extended prefix routes.";
+}
+
+revision 2018-02-20 {
+description
+"Add global ECN ECT control flag.";
+}
+
+revision 2014-08-06 {
+description
+"Initial revision.";
+}
+
+/*
+* Typedefs
+*/
+
+/*
+* Identities
+*/
+
+identity switch-element-base {
+	description "Base identity from which specific routing protocols are derived.";
+}
+
+/*
+* Configuration of the core elements of the Switch
+*/
+
+typedef hash-algorithm {
+    type enumeration {
+	      enum "XOR" {
+	        value 1;
+	      }
+	      enum "CRC" {
+	      	value 2;
+	      }
+	      enum "RANDOM" {
+	      	value 3;
+	      }
+    }
+}
+
+typedef switching-mode {
+    type enumeration {
+	      enum "cut-through" {
+	        value 1;
+	      }
+	      enum "store-and-forward" {
+	      	value 2;
+	      }
+    }
+}
+
+typedef hash-fields {
+    type enumeration {
+	      enum "src-ip" {
+	        value 1;
+	      }
+	      enum "dest-ip" {
+	        value 2;
+	      }
+	      enum "vlan-id" {
+	        value 3;
+	      }
+	      enum "ip-protocol" {
+	        value 4;
+	      }
+	      enum "ethertype" {
+	        value 5;
+	      }
+	      enum "l4-src-port" {
+	        value 6;
+	      }
+	      enum "l4-dest-port" {
+	        value 7;
+	      }
+	      enum "src-mac" {
+	        value 8;
+	      }
+	      enum "dest-mac" {
+	        value 9;
+	      }
+	      enum "in-port" {
+	        value 10;
+	      }
+    }
+}
+
+    typedef subsystem{
+        description "Switch Subsystem Ids";
+        type enumeration{
+            enum "unspecified"{
+                value 1;
+            }
+            enum "switch"{
+                value 2;
+            }
+            enum "port"{
+                value 3;
+            }
+            enum "fdb"{
+                value 4;
+            }
+            enum "vlan"{
+                value 5;
+            }
+            enum "virtual-router"{
+                value 6;
+            }
+             enum "route"{
+                value 7;
+            }
+            enum "next-hop"{
+                value 8;
+            }
+            enum "next-hop-group"{
+                value 9;
+            }
+            enum "router-interface"{
+                value 10;
+            }
+            enum "neighbor"{
+                value 11;
+            }
+            enum "acl"{
+                value 12;
+            }
+             enum "host_interface"{
+                value 13;
+            }
+            enum "mirror"{
+                value 14;
+            }
+            enum "samplepacket"{
+                value 15;
+            }
+            enum "stp"{
+                value 16;
+            }
+            enum "lag"{
+                value 17;
+            }
+            enum "policer"{
+                value 18;
+            }
+             enum "wred"{
+                value 19;
+            }
+            enum "qos-maps"{
+                value 20;
+            }
+            enum "qos-queue"{
+                value 21;
+            }
+            enum "scheduler"{
+                value 22;
+            }
+            enum "scheduler-group"{
+                value 23;
+            }
+            enum "all"{
+
+            }
+        }
+    }
+
+    typedef log-level{
+        description "Switch Subsystem log levels";
+        type enumeration{
+            enum "debug"{
+                value 1;
+            }
+            enum "info"{
+                value 2;
+            }
+            enum "notice"{
+                value 3;
+            }
+            enum "warning"{
+                value 4;
+            }
+            enum "error"{
+                value 5;
+            }
+            enum "critical"{
+                value 6;
+            }
+        }
+    }
+
+    typedef profile-name {
+        type string {
+            length "1..32";
+        }
+    }
+    typedef uft-mode {
+        type enumeration {
+            enum "default-mode" {
+              value 1;
+            }
+            enum "scaled-l2" {
+              value 2;
+            }
+            enum "scaled-l3-routes" {
+              value 3;
+            }
+            enum "scaled-l3-hosts" {
+              value 4;
+            }
+        }
+    }
+
+    grouping mode-info {
+        leaf l2-mac-table-size {
+            type uint32;
+            description "l2 table size";
+        }
+        leaf l3-route-table-size {
+            type uint32;
+            description "l3 table size";
+        }
+        leaf host-table-size {
+            type uint32;
+            description "ARP/NBR table size";
+        }
+    }
+
+
+list switching-entity-env {
+    key "switch-id";
+    description  "the list of switching entities environment.";
+
+    leaf switch-id {
+        type base-cmn:logical-switch-id;
+        description "Switch Identifier";
+    }
+
+    leaf temperature {
+        type int32;
+        description "Current temperature of NPU";
+    }
+}
+
+container switching-entities {
+
+  description "switching entity configuration parameters.";
+  leaf switch-count {
+    type uint32;
+    description "The number of virtual switches on the platform";
+  }
+
+  list switching-entity {
+    key "switch-id";
+    description  "the list of switching entities.";
+	
+    leaf switch-id {
+        type base-cmn:logical-switch-id;
+        description "Switch Identifier";
+    }
+
+    leaf switch-mode {
+    	type switching-mode;
+    	description "the default mode for switching packets";
+    }
+
+    leaf lag-hash-algorithm {
+    	type hash-algorithm;
+    	description "The switches hash algorithm setting";
+    }
+
+    leaf lag-hash-seed-value {
+        type uint32;
+        description "The switch lag hash seed value";
+    }
+    leaf-list lag-hash-fields {
+    	type hash-fields;
+    	description "The switches hash fields used for lags";
+    }
+
+    leaf-list npu-identifiers {
+        type base-cmn:npu-id;
+        description "The NPUs associated with the virtual switch";
+    }
+
+    leaf operational-status{
+        config false;
+        type base-cmn:oper-status-type;
+    }
+
+    leaf admin-status{
+        type base-cmn:admin-status-type;
+    }
+
+    leaf bridge-table-size {
+        config false;
+        type uint32;
+        description "Size of Layer2 FDB";
+    }
+
+    leaf max-supported-lags {
+        config false;
+        type uint32;
+        description "The maximum number of lags this device supports";
+    }
+
+    leaf ecmp-hash-algorithm {
+    	type hash-algorithm;
+    	description "The switch ecmp hash algorithm setting";
+    }
+
+    leaf ecmp-hash-seed-value {
+        type uint32;
+        description "The switch ecmp hash seed value";
+    }
+
+    leaf-list ecmp-hash-fields {
+    	type hash-fields;
+    	description "The fields used for hasing in the case of ecmp";
+    }
+
+    leaf ecmp-group-size {
+        type uint32;
+        description "Maximum number of ECMP groups";
+    }
+    leaf max-ecmp-entry-per-group {
+        type uint32 {range "2..1024";}
+        default 64;
+        description "Configure maximum ECMP entries per group";
+    }
+    leaf ipv4-route-table-size {
+        config false;
+        type uint32;
+        description "Size of IPv4 Routing table";
+    }
+
+    leaf ipv6-route-table-size {
+        config false;
+        type uint32;
+        description "Size of IPv6 Routing table";
+    }
+
+    leaf ipv4-host-size {
+        config false;
+        type uint32;
+        description "Size of IPv4 NBR table";
+    }
+
+    leaf ipv6-host-size {
+        config false;
+        type uint32;
+        description "Size of IPv6 NBR table";
+    }
+
+    leaf num-unicast-queues-per-port {
+        type uint32;
+    }
+
+    leaf num-multicast-queues-per-port {
+        type uint32;
+    }
+
+    leaf num-queues-per-port {
+        type uint32;
+        default 8;
+    }
+
+    leaf num-queues-cpu-port {
+        type uint32;
+    }
+
+    leaf qos-rate-adjust {
+        type uint32;
+        default 0;
+        description "QoS rate adjustment due to internal overhead bytes";
+    }
+
+    leaf ingress-flow-table-size {
+        type uint32;
+        default 4096; /* 4K entries */
+    }
+
+    leaf egress-flow-table-size {
+        type uint32;
+        default 2048; /* 2K entries */
+    }
+
+    leaf mac-age-timer {
+        type uint32;
+        description "Timeout period for dynamically leanrt MAC Addresses";
+    }
+
+    leaf default-vlan-id {
+       type base-cmn:vlan-id;
+       description "The default vlan-id for this switch";
+    }
+
+    leaf disable-default-vlan {
+         type boolean;
+         description "Disable the default vlan for the switch";
+    }
+
+    leaf default-mac-address {
+    	type yang:mac-address;
+    	description "This will be the default MAC address for the switch.";
+    }
+    leaf temperature { /* Deprecated, moved temperature leaf to switching-entity-env object */
+        type int32;
+        description "Current temperature of NPU";
+    }
+
+    leaf acl-table-min-priority {
+    	type uint32;
+       config false;
+    	description "Lowest ACL table priority supported.";
+    }
+    leaf acl-table-max-priority {
+        type uint32;
+        config false;
+        description "Highest ACL table priority supported.";
+    }
+    leaf acl-entry-min-priority {
+        type uint32;
+        config false;
+        description "Lowest ACL entry priority supported.";
+    }
+    leaf acl-entry-max-priority {
+        type uint32;
+        config false;
+        description "Highest ACL entry priority supported.";
+    }
+    leaf max-mtu {
+        type uint32;
+        config false;
+        description "Maximum MTU supported.";
+    }
+    leaf total-buffer-size {
+        type uint32;
+        config false;
+        description "switch total buffer size in KB.";
+    }
+    leaf ingress-buffer-pool-num {
+        type uint32;
+        config false;
+        description "switch total number of ingress buffer pools";
+    }
+    leaf egress-buffer-pool-num {
+        type uint32;
+        config false;
+        description "switch total number of egress buffer pools";
+    }
+    leaf counter-refresh-interval{
+        type uint32;
+        description "Time interval in seconds at which the counters will be read from NPU";
+    }
+    leaf switch-profile {
+        type profile-name;
+        description "configure switch profile, each profile will have different set of ports with
+                    differnt speeds conbination";
+    }
+    leaf-list supported-profiles {
+        config false;
+        type profile-name;
+        description "list of all supported switch profiles for a given platform";
+    }
+    leaf default-profile {
+        config false;
+        type profile-name;
+        description "default switch profile";
+    }
+    leaf uft-mode {
+        type uft-mode;
+        description "configured Unified Forwarding Table (UFT) mode";
+        default "default-mode";
+    }
+    list uft-mode-info {
+        config false;
+        description "describes the table size values for the given mode. by default
+                    returns all the modes and their respective table size";
+        key "mode";
+        leaf mode {
+            type uft-mode;
+            description "Unified Forwarding Table (UFT) mode";
+        }
+        uses mode-info;
+    }
+
+    leaf ecn-ect-threshold-enable {
+        type boolean;
+        description "Globally enable/disable ECN ECT thresholds";
+    }
+
+    leaf ipv6-extended-prefix-routes {
+        type uint32;
+        default 0;
+        description "Configure number of extended IPv6 prefix routes with the mask length of /65 to /128 in LPM table";
+    }
+
+    leaf max-ipv6-extended-prefix-routes {
+        config false;
+        type uint32;
+        description "Maximum number of extended IPv6 prefix routes with the mask length of /65 to /128 supported in LPM table";
+    }
+
+    leaf ipv6-extended-prefix-routes-lpm-block-size {
+        config false;
+        type uint32;
+        description "Configuration of extended IPv6 prefix routes with the mask length of /65 to /128 in LPM table supports in multiples of blocks, This is for each block size.";
+    }
+  }
+}
+
+
+rpc diag_shell {
+	description "This RPC allows debug access to the switch to perform some basic status
+		commands.";
+    input {
+        leaf command {
+            type string;
+            description "A valid diagnostic shell command.";
+        }
+    }
+    output {
+        leaf result {
+            type string;
+            description "The commmand output as a string.  This string will need to be parsed
+            	and is not standard.";
+        }
+    }
+}
+
+rpc set_log {
+    description
+    "This RPC allows to change the switch subsystem log level";
+
+    input {
+        leaf subsystem-id {
+            type subsystem;
+            description "Subsytem id of the switch";
+        }
+
+        leaf level {
+            type log-level;
+            description "Log level to be set";
+        }
+    }
+}
+
+}
+
+
+
+
+
+

--- a/python-inocybe-openswitch/models/base-udf.yang
+++ b/python-inocybe-openswitch/models/base-udf.yang
@@ -1,0 +1,243 @@
+module base-udf {
+
+    namespace "http://www.dellemc.com/networking/os10/dell-base-udf";
+    prefix "base-udf";
+
+    import base-common {
+        prefix "base-cmn";
+    }
+
+    import ietf-inet-types {
+        prefix "inet";
+    }
+
+    organization
+        "Dell EMC";
+
+    contact
+        "http://www.dell.com/support";
+
+    description
+        "This module contains a collection of YANG definitions
+        for managing User Defined Filters (UDFs).
+
+        Copyright (c) 2015-2016 by Dell EMC,
+        All rights reserved.";
+
+    revision 2016-10-04 {
+        description "Initial revision";
+    }
+
+    typedef udf-group-type {
+        type enumeration {
+            enum GENERIC {
+                value 1;
+                description "Generic UDF Group";
+            }
+
+            enum HASH {
+                value 2;
+                description "UDF Group for HASH";
+            }
+        }
+    }
+
+    list udf-group {
+        key "id";
+
+        description
+            "List contains attributes of UDF Group object.";
+
+        leaf id {
+            type base-cmn:base-obj-id-type;
+            description "Unique ID generated upon Create request.
+                         Subsequent Modify and Delete request required
+                         this Group ID to be passed in.";
+        }
+
+        leaf type {
+            mandatory true;
+            type udf-group-type;
+            description "Type of UDF Group to be created";
+        }
+
+        leaf length {
+            mandatory true;
+            type uint8;
+            description "Length of bytes for the UDF objects in the group";
+        }
+
+        leaf-list udf-id-list {
+            config false;
+            type base-cmn:base-obj-id-type;
+            description "List of UDF object IDs associated with this UDF Group";
+        }
+
+        leaf-list npu-id-list {
+            type base-cmn:npu-id;
+            description
+                "Optional subset of NPUs on which this UDF Group needs to be installed.
+                 If this atttribute is not specified then the UDF Group is installed on
+                 all NPUs to which the UDF Group belongs.";
+        }
+    }
+
+    typedef udf-match-type {
+        type enumeration {
+            enum NON_TUNNEL {
+                value 1;
+                description "Match packets without tunnel encapsulation.";
+            }
+
+            enum GRE_TUNNEL {
+                value 2;
+                description "Match packets with GRE tunnel encapsulation.";
+            }
+        }
+    }
+
+    list udf-match {
+        key "id";
+
+        description
+            "List contains attributes of UDF Match object.";
+
+        leaf id {
+            type base-cmn:base-obj-id-type;
+            description "Unique ID generated upon Create request.
+                         Subsequent Modify and Delete request required
+                         this Match ID to be passed in.";
+        }
+
+        leaf priority {
+            mandatory true;
+            type uint8;
+            description "UDF Match priority.";
+        }
+
+        leaf type {
+            mandatory true;
+            type udf-match-type;
+            description "Specify encapsulation type of packets this UDF Match
+                         object is going to match";
+        }
+
+        container NON_TUNNEL_VALUE {
+            when "../type = NON_TUNNEL";
+
+            leaf l2-type {
+                mandatory true;
+                type uint16;
+                description "Protocol type of L2 header";
+            }
+
+            leaf l2-type-mask {
+                type uint16;
+                description "Protocol type mask of L2 header";
+            }
+
+            leaf l3-type {
+                mandatory true;
+                type uint8;
+                description "Protocol type of L3 header";
+            }
+
+            leaf l3-type-mask {
+                type uint8;
+                description "Protocol type mask of L3 header";
+            }
+        }
+
+        container GRE_TUNNEL_VALUE {
+            when "../type = GRE_TUNNEL";
+
+            leaf inner-type {
+                mandatory true;
+                type inet:ip-version;
+                description "Type of inner IP header";
+            }
+
+            leaf outer-type {
+                type inet:ip-version;
+                description "Type of outer IP header";
+            }
+        }
+
+        leaf-list npu-id-list {
+            type base-cmn:npu-id;
+            description
+                "Optional subset of NPUs on which this UDF Match needs to be installed.
+                 If this atttribute is not specified then the UDF Match is installed on
+                 all NPUs to which the UDF Match belongs.";
+        }
+    }
+
+    typedef udf-base-type {
+        type enumeration {
+            enum L2 {
+                value 1;
+                description "UDF offset base L2 header";
+            }
+
+            enum L3 {
+                value 2;
+                description "UDF offset base L3 header";
+            }
+
+            enum L4 {
+                value 3;
+                description "UDF offset base L4 header";
+            }
+        }
+    }
+
+    list udf-obj {
+        key "id";
+
+        description
+            "List contains attributes of UDF object.";
+
+        leaf id {
+            type base-cmn:base-obj-id-type;
+            description "Unique ID generated upon Create request.
+                         Subsequent Modify and Delete request required
+                         this UDF ID to be passed in.";
+        }
+
+        leaf group-id {
+            mandatory true;
+            type base-cmn:base-obj-id-type;
+            description "UDF Group ID associated with this UDF object";
+        }
+
+        leaf match-id {
+            mandatory true;
+            type base-cmn:base-obj-id-type;
+            description "UDF Match ID associated with this UDF object";
+        }
+
+        leaf base {
+            mandatory true;
+            type udf-base-type;
+            description "Base of the UDF";
+        }
+
+        leaf offset {
+            type uint32;
+            description "Offset from the base of the UDF";
+        }
+
+        leaf-list hash-mask {
+            type uint8;
+            description "Hash mask bytes to be used for the UDF Hash field";
+        }
+
+        leaf-list npu-id-list {
+            type base-cmn:npu-id;
+            description
+                "Optional subset of NPUs on which this UDF Object needs to be installed.
+                 If this atttribute is not specified then the UDF Object is installed on
+                 all NPUs to which the UDF Object belongs.";
+        }
+    }
+}

--- a/python-inocybe-openswitch/models/dell-base-if-common.yang
+++ b/python-inocybe-openswitch/models/dell-base-if-common.yang
@@ -1,0 +1,185 @@
+module dell-base-if-common {
+    namespace "http://www.dellemc.com/networking/os10/base/dell-base-if-common";
+
+    prefix "dell-base-if-cmn";
+
+    import ietf-interfaces {
+        prefix "if";
+    }
+    import ietf-yang-types {
+        prefix "yang";
+    }
+    import base-common {
+        prefix "base-cmn";
+    }
+
+    import dell-interface {
+        prefix "dell-if";
+    }
+    organization "Dell EMC";
+    contact "http://www.dell.com/support";
+
+    description "This model augments the standard interface and adds Dell EMC specific
+                    extensions.  This model contains the entry point for the
+                    interface object extensions.";
+
+    revision "2018-05-08" {
+        description "Added support for VLAN filtering object. This object helps to
+                     get or set VLAN filtering feature on an interface";
+        reference "IEEE 802.1Q";
+    }
+
+    revision "2018-01-22" {
+        description "Augmented if/interfaces model from dell-interface to handle the
+                     attributes augmented in dell-interface.yang";
+    }
+
+    revision "2017-10-10" {
+        description "Add typedef for update type to use it for leaf list attribute type.
+                     Add member-op attribute for rpc set-interface to handle leaf-list update";
+    }
+
+    revision "2016-01-01" {
+        description "Initial version.";
+    }
+
+
+    augment "/if:interfaces/if:interface" {
+        description "The following attributes are common to all interface types.";
+
+        leaf if-index {
+            type base-cmn:logical-ifindex;
+            description "Can be used as an alternate to the name key field.  The if-index is the linux representation for the interface.";
+        }
+
+        leaf vlan-filter {
+            type base-cmn:filter-type;
+            default "INGRESS_ENABLE";
+            description "Used to enable or disable VLAN filtering flag on an interface. By default, Ingress VLAN Filter is enabled";
+        }
+    }
+
+    augment "/if:interfaces-state/if:interface" {
+        leaf vlan-filter {
+            type base-cmn:filter-type;
+            description "Used to get the status of Interface VLAN filtering flag";
+        }
+    }
+
+    augment "/if:interfaces-state/if:interface/if:statistics" {
+
+        leaf time-stamp{
+            type yang:timestamp;
+            description "Timestamp at which stats are returned";
+        }
+    }
+
+    typedef operation-type {
+        description "Operation type of interface configuration";
+
+        type enumeration {
+            enum CREATE {
+                value 1;
+                description "Operation to create interface";
+            }
+            enum DELETE {
+                value 2;
+                description "Operation to delete interface";
+            }
+            enum UPDATE {
+                value 3;
+                description "Operation to update interface attributes";
+            }
+        }
+    }
+    typedef update-type {
+        type enumeration {
+            enum ADD {
+                value 1;
+                description "Operation to add member";
+            }
+            enum REMOVE {
+                value 2;
+                description "Operation to remove member";
+            }
+        }
+    }
+
+
+    rpc set-interface {
+        description "This method is used to create, delete or set multiple types of interface. For
+                create operation, mac address will be allocated if it is not given within input argument.
+                Currently there is only one input argument which specified operation type, user should
+                use attributes of the model of corresponding interface type as extra input.
+                if:interface model is used as input for interface configuration.";
+
+        // QUALIFIER  :  target
+        // ========
+        //
+        // OBJ PATH : dell-base-if-cmn/set-interface
+        // ========
+        //
+        // INPUT  :
+        // =====
+        // a) Explicit:
+        //    --------
+        //              dell-base-if-cmn/set-interface/input/operation (1=create, 2=delete, 3=update),
+        //              dell-base-if-cmn/set-interface/input/member-op (1=add, 2=remove),
+        // b) Implicit:
+        //    --------
+        //    Users could use additional attributes from other models (eg. if, base-if-phy etc.)
+        //    Eg.
+        //            	if/interfaces/interface/name,
+        //             	if/interfaces/interface/type,
+        //             	if/interfaces/interface/enabled,
+        //             	if/interfaces/interface/mtu,
+        //             	if/interfaces/interface/learn-mode,
+        //             	if/interfaces/interface/tagging-mode(For Phy Interface Only),
+        //             	if/interfaces/interface/speed(For Phy Interface Only),
+        //             	if/interfaces/interface/auto-negotiation(For Phy Interface Only),
+        //             	if/interfaces/interface/duplex(For Phy Interface Only),
+        //             	if/interfaces/interface/eee(For Phy Interface Only),
+        //             	if/interfaces/interface/fec(For Phy Interface Only),
+        //             	if/interfaces/interface/oui(For Phy Interface Only),
+        //             	if/interfaces/interface/type(For Phy Interface Only),
+        //              Etc.
+        // OUTPUT :
+        // ======
+        // a) Explicit:
+        //    --------
+        //	        None.
+        // b) Implicit:
+        //    -------
+        //              dell-base-if-cmn/if/interfaces/interface/if-index.
+
+        input {
+            leaf operation {
+                description "Specify operation type to configure interface.";
+                type operation-type;
+            }
+            leaf member-op {
+                description " Specify the operation type in case of member add or remove. This field is optional
+                              and member list is considered a complete list in case if member-op is not present.";
+                type update-type;
+            }
+        }
+    }
+
+    rpc get-mac-address {
+        description "This method is used to get assgined mac address for different type of interfaces.
+                User should give required attributes such as interface-name, type as input. The actual
+                attributes needed depends on requested interface type";
+    }
+
+    augment "dell-if:clear-counters/dell-if:input" {
+
+    }
+
+    augment "dell-if:clear-eee-counters/dell-if:input" {
+
+    }
+
+    augment "/if:interfaces"{
+
+    }
+}

--- a/python-inocybe-openswitch/models/port-group.yang
+++ b/python-inocybe-openswitch/models/port-group.yang
@@ -1,0 +1,217 @@
+module port-group {
+    namespace "http://www.dellemc.com/networking/os10/dell-port-group";
+
+    prefix "pg";
+
+    import base-common {
+        prefix "base-cmn";
+    }
+
+	import base-interface-common {
+		prefix "base-if";
+	}
+
+    organization "Dell EMC";
+    contact "http://www.dell.com/support";
+
+    description "This model contains Dell EMC specific port-group defintion and its attributes.";
+
+	revision "2018-04-10" {
+        description "Adding supported-profiles to hybrid-group state object to 
+                     publish list of profile modes supported on hybrid-group.";
+        reference "Network Platform Abstraction";
+    }
+
+    revision "2018-03-15" {
+        description "Added hybrid port groups to the config and state objects.
+                     A hybrid port-group permits individual member ports to be
+                     independently programmed with different breakout modes.";
+        reference "Network Platform Abstraction";
+    }
+
+    revision "2016-11-22" {
+        description "Initial version.";
+    }
+
+    container port-groups {
+
+        list port-group {
+            key "id";
+
+            description "This map contains the port group and its configurable attributes.";
+
+            leaf id {
+                type string;
+                description "ID of the port group ";
+            }
+
+            leaf phy-mode {
+                type base-if:phy-mode-type;
+                description "Port PHY mode, Ethernet or FC";
+            }
+
+            leaf breakout-mode {
+                description "this is the new breakout mode to configure.";
+                type base-cmn:breakout-type;
+            }
+
+            leaf port-speed {
+                type base-if:speed;
+                description "Max line speed of the breakout port. This indicates the max line rate at which
+                individual ports will operate post breakout";
+            }
+        }
+
+        list hybrid-group {
+            key "id";
+            description
+                "This is a list of hybrid port groups on the system with configurable attributes. Hybrid group consist
+                 group of ports that can be configured with different breakout mode using profiles";
+
+            leaf id {
+                type string;
+                description
+                    "ID of the hybrid port group.";
+            }
+
+	    	leaf profile {
+				type string;
+				description
+		    		"Name of the profile configured on the hybrid port-group";
+            }
+
+            list port {
+                key "port-id";
+                description
+                    "List of ports that are members of the hybrid port group.";
+
+                leaf port-id {
+                    type string;
+                    description
+                        "ID of the hybrid group member port.";
+                }
+
+                leaf phy-mode {
+                    type base-if:phy-mode-type;
+                    description
+                        "Configured Port PHY mode, Ethernet or FC.";
+                }
+
+                leaf breakout-mode {
+                    type base-cmn:breakout-type;
+                    description
+                        "Configured breakout mode on the port.";
+                }
+
+                leaf port-speed {
+                    type base-if:speed;
+                    description
+                        "Configured max line speed of the breakout port. This
+                         indicates the max line rate at which individual ports
+                         will operate post breakout.";
+                }
+            }
+        }
+
+    }
+
+    container port-groups-state {
+        config false;
+        list port-group-state {
+            key "id";
+
+            description "This map contains the port group , theassociated front panel ports
+            and its configuration properties and capabilities.";
+
+            leaf id {
+                type string;
+                description "ID of the port group ";
+            }
+
+            uses base-if:breakout-capabilities;
+
+            leaf default-phy-mode {
+                type base-if:phy-mode-type;
+                description "Default Port PHY mode, Ethernet or FC";
+            }
+
+            leaf default-breakout-mode {
+                description "Default breakout mode for the port-group";
+                type base-cmn:breakout-type;
+            }
+
+            leaf default-port-speed {
+                type base-if:speed;
+                description "Default breakout speed of the port-gorup";
+            }
+            
+        }
+
+        list hybrid-group-state {
+            key "id";
+            description
+                "This is a list of hybrid port groups on the system with
+                 state information.";
+
+            leaf id {
+                type string;
+                description
+                    "ID of the hybrid port group.";
+            }
+
+            leaf default-profile {
+                type string;
+                description
+                    "Name of the default profile on the hybrid port group.";
+            }
+
+            uses base-if:supported-profiles;
+
+            list port {
+                key "port-id";
+                description
+                    "List of ports in the hybrid port group.";
+
+                leaf port-id {
+                    type string;
+                    description
+                        "ID of the hybrid group member port.";
+                }
+
+                list profile {
+                    key "name";
+                    description
+                        "List of profiles in the hybrid port group. Includes
+                         port capabilities and defaults per profile.";
+
+                    leaf name {
+                        type string;
+                        description
+                            "Name of the profile.";
+                    }
+
+                    uses base-if:breakout-capabilities;
+
+                    leaf default-phy-mode {
+                        type base-if:phy-mode-type;
+                        description
+                            "Default Port PHY mode, Ethernet or FC in this profile.";
+                    }
+
+                    leaf default-breakout-mode {
+                        type base-cmn:breakout-type;
+                        description
+                            "Default breakout mode on the port in this profile.";
+                    }
+
+                    leaf default-port-speed {
+                        type base-if:speed;
+                        description
+                            "Default max line speed of the breakout port in this profile.";
+                    }
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
1. Update models and hack them to conform to ODL/Upstream
conventions (ip-address is ip address instead of binary
blob, etc).
2. Update parser to accommodate a couple of new fields
returned by interface queries. Clearly incomplete, but we need
to start looking into solving this long term instead of
adlibing it.

Signed-off-by: Anton Ivanov <anton.ivanov@cambridgegreys.com>